### PR TITLE
Integrate `iyes_progress` for progress tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
       - name: Build & run tests for all feature combinations
-        run: cargo hack test --feature-powerset --group-features 2d,3d
+        run: cargo hack test --feature-powerset --group-features "2d","3d"
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-hack
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
-      - name: Install cargo-hack
-        run: |
-          cargo install cargo-hack --force
       - name: Build & run tests for all feature combinations
-        run: cargo hack test --feature-powerset
+        run: cargo hack test --feature-powerset --group-features 2d,3d
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Support progress tracking through `iyes_progress` ([#6](https://github.com/NiklasEi/bevy_asset_loader/issues/6))
 - Allow adding dynamic asset collection files to a resource instead of only the Plugin builder
 - Make file endings for dynamic asset collections configurable ([#38](https://github.com/NiklasEi/bevy_asset_loader/issues/38))
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ With the feature `progress_tracking`, you can integrate with [`iyes_progress`][i
 
 See [`progress_tracking`](/bevy_asset_loader/examples/progress_tracking.rs) for a complete example.
 
+### A note on system ordering
+
+The loading state runs in a single exclusive system `at_start`. This means that any parallel system in the loading state will always run after all asset handles have been checked for their status. You can thus read the current progress in each frame in a parallel system without worrying about frame lag. 
+
 ## Usage without a loading state
 
 Although the pattern of a loading state is quite nice, you might have reasons not to use it. In this case `bevy_asset_loader` can still be helpful. Deriving `AssetCollection` on a resource can significantly reduce the boilerplate for managing assets.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ struct ImageAssets {
 }
 ```
 
-The key `player` in the above example should be either set manually in the `DynamicAssets` resource before the loading state (see the [dynamic_asset](bevy_asset_loader/examples/dynamic_asset.rs) example), or should be part of a `.assets` file in ron format (the file ending can be configured):
+The key `player` in the above example should be either set manually in the `DynamicAssets` resource before the loading state (see the [dynamic_asset](/bevy_asset_loader/examples/dynamic_asset.rs) example), or should be part of a `.assets` file in ron format (the file ending can be configured):
 
 ```ron
 ({
@@ -95,7 +95,7 @@ The key `player` in the above example should be either set manually in the `Dyna
 })
 ```
 
-Loading dynamic assets from such a `.ron` file requires the feature `dynamic_assets` and a little setup. Take a look at the [dynamic_asset_ron](bevy_asset_loader/examples/dynamic_asset_ron.rs) example to see what this can look like in your game.
+Loading dynamic assets from such a `.ron` file requires the feature `dynamic_assets` and a little setup. Take a look at the [dynamic_asset_ron](/bevy_asset_loader/examples/dynamic_asset_ron.rs) example to see what this can look like in your game.
 
 ### Loading a folder as asset
 
@@ -185,6 +185,12 @@ In situations where you would like to prepare other resources based on your load
 
 `AssetLoader::init_resource` does the same as Bevy's `App::init_resource`, but at a different point in time. While Bevy inserts your resources at the very beginning, the AssetLoader will do so after having inserted your loaded asset collections. That means that you can use your asset collections in the `FromWorld` implementations.
 
+## Progress tracking
+
+With the feature `progress_tracking`, you can integrate with [`iyes_progress`][iyes_progress] to track asset loading during a loading state. This, for example, enables progress bars.
+
+See [`progress_tracking`](/bevy_asset_loader/examples/progress_tracking.rs) for a complete example.
+
 ## Usage without a loading state
 
 Although the pattern of a loading state is quite nice, you might have reasons not to use it. In this case `bevy_asset_loader` can still be helpful. Deriving `AssetCollection` on a resource can significantly reduce the boilerplate for managing assets.
@@ -227,12 +233,12 @@ Compatibility of `bevy_asset_loader` versions:
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](/LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](/LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 
-Assets in the examples might be distributed under different terms. See the [readme](bevy_asset_loader/examples/README.md#credits) in the `bevy_asset_loader/examples` directory.
+Assets in the examples might be distributed under different terms. See the [readme](/bevy_asset_loader/examples/README.md#credits) in the `bevy_asset_loader/examples` directory.
 
 ## Contribution
 
@@ -242,3 +248,4 @@ additional terms or conditions.
 
 [bevy]: https://bevyengine.org/
 [cheatbook-states]: https://bevy-cheatbook.github.io/programming/states.html
+[iyes_progress]: https://github.com/IyesGames/iyes_progress

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -24,19 +24,19 @@ readme = "../README.md"
     "bevy_asset_loader_derive/3d",
 ]
 dynamic_assets = ["bevy_asset_ron", "serde"]
-progress_tracking = ["bevy_loading"]
+progress_tracking = ["iyes_progress"]
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
 bevy_asset_loader_derive = { version = "=0.11.0-github.main", path = "../bevy_asset_loader_derive" }
 bevy_asset_ron = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
-#bevy_loading = { path = "../../bevy_loading", optional = true }
-bevy_loading = { git = "https://github.com/NiklasEi/bevy_loading", branch = "simplify_ordering", optional = true }
+#iyes_progress = { path = "../../bevy_loading", optional = true }
+iyes_progress = { git = "https://github.com/IyesGames/iyes_progress", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.7", features = ["vorbis"] }
-bevy_loading = { git = "https://github.com/NiklasEi/bevy_loading", branch = "simplify_ordering" }
+iyes_progress = { git = "https://github.com/IyesGames/iyes_progress" }
 trybuild = "1.0"
 
 [[example]]

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -31,7 +31,6 @@ bevy = { version = "0.7", default-features = false }
 bevy_asset_loader_derive = { version = "=0.11.0-github.main", path = "../bevy_asset_loader_derive" }
 bevy_asset_ron = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
-#iyes_progress = { path = "../../bevy_loading", optional = true }
 iyes_progress = { git = "https://github.com/IyesGames/iyes_progress", optional = true }
 
 [dev-dependencies]

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -24,15 +24,19 @@ readme = "../README.md"
     "bevy_asset_loader_derive/3d",
 ]
 dynamic_assets = ["bevy_asset_ron", "serde"]
+progress_tracking = ["bevy_loading"]
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
 bevy_asset_loader_derive = { version = "=0.11.0-github.main", path = "../bevy_asset_loader_derive" }
 bevy_asset_ron = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
+#bevy_loading = { path = "../../bevy_loading", optional = true }
+bevy_loading = { git = "https://github.com/NiklasEi/bevy_loading", branch = "simplify_ordering", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.7", features = ["vorbis"] }
+bevy_loading = { git = "https://github.com/NiklasEi/bevy_loading", branch = "simplify_ordering" }
 trybuild = "1.0"
 
 [[example]]
@@ -65,3 +69,8 @@ path = "examples/no_loading_state.rs"
 name = "standard_material"
 path = "examples/standard_material.rs"
 required-features = ["3d"]
+
+[[example]]
+name = "progress_tracking"
+path = "examples/progress_tracking.rs"
+required-features = ["progress_tracking"]

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -31,11 +31,11 @@ bevy = { version = "0.7", default-features = false }
 bevy_asset_loader_derive = { version = "=0.11.0-github.main", path = "../bevy_asset_loader_derive" }
 bevy_asset_ron = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
-iyes_progress = { git = "https://github.com/IyesGames/iyes_progress", optional = true }
+iyes_progress = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.7", features = ["vorbis"] }
-iyes_progress = { git = "https://github.com/IyesGames/iyes_progress" }
+iyes_progress = { version = "0.3" }
 trybuild = "1.0"
 
 [[example]]

--- a/bevy_asset_loader/examples/progress_tracking.rs
+++ b/bevy_asset_loader/examples/progress_tracking.rs
@@ -1,0 +1,73 @@
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use bevy_asset_loader::{AssetCollection, AssetLoader};
+use bevy_loading::{LoadingPlugin, ProgressCounter};
+
+/// This example shows how to track the loading progress of your collections using `bevy_loading`
+///
+/// Running it will print the current progress for every frame. The five assets from
+/// the two collections will be loaded rather quickly (one or two frames). The final task
+/// completes after three seconds. At that point `bevy_loading` will progress to the next state
+/// and the app will terminate.
+fn main() {
+    let mut app = App::new();
+    AssetLoader::new(MyStates::AssetLoading)
+        .with_collection::<TextureAssets>()
+        .with_collection::<AudioAssets>()
+        .build(&mut app);
+    app.add_state(MyStates::AssetLoading)
+        .add_plugins(DefaultPlugins)
+        // track progress during `MyStates::AssetLoading` and continue to `MyStates::Next` when progress is completed
+        .add_plugin(LoadingPlugin::new(MyStates::AssetLoading).continue_to(MyStates::Next))
+        // gracefully quit the app when `MyStates::Next` is reached
+        .add_system_set(SystemSet::on_enter(MyStates::Next).with_system(quit))
+        .add_system_set(
+            SystemSet::on_update(MyStates::AssetLoading).with_system(track_fake_long_task),
+        )
+        .add_system_to_stage(CoreStage::PostUpdate, print_progress)
+        .run();
+}
+
+#[derive(AssetCollection)]
+struct AudioAssets {
+    #[asset(path = "audio/background.ogg")]
+    _background: Handle<AudioSource>,
+    #[asset(path = "audio/plop.ogg")]
+    _plop: Handle<AudioSource>,
+}
+
+#[derive(AssetCollection)]
+struct TextureAssets {
+    #[asset(path = "images/player.png")]
+    _player: Handle<Image>,
+    #[asset(path = "images/tree.png")]
+    _tree: Handle<Image>,
+    #[asset(path = "images/female_adventurer.png")]
+    _female_adventurer: Handle<Image>,
+}
+
+fn track_fake_long_task(time: Res<Time>, progress: Res<ProgressCounter>) {
+    if time.seconds_since_startup() > 2. {
+        info!("done");
+        progress.manually_track(true.into());
+    } else {
+        progress.manually_track(false.into());
+    }
+}
+
+fn quit(mut quit: EventWriter<AppExit>) {
+    info!("quitting");
+    quit.send(AppExit);
+}
+
+fn print_progress(progress: Option<Res<ProgressCounter>>) {
+    if let Some(progress) = progress {
+        info!("Current progress: {:?}", progress.progress());
+    }
+}
+
+#[derive(Component, Clone, Eq, PartialEq, Debug, Hash, Copy)]
+enum MyStates {
+    AssetLoading,
+    Next,
+}

--- a/bevy_asset_loader/examples/progress_tracking.rs
+++ b/bevy_asset_loader/examples/progress_tracking.rs
@@ -1,13 +1,13 @@
 use bevy::app::AppExit;
 use bevy::prelude::*;
 use bevy_asset_loader::{AssetCollection, AssetLoader};
-use bevy_loading::{LoadingPlugin, ProgressCounter};
+use iyes_progress::{ProgressCounter, ProgressPlugin};
 
-/// This example shows how to track the loading progress of your collections using `bevy_loading`
+/// This example shows how to track the loading progress of your collections using `iyes_progress`
 ///
 /// Running it will print the current progress for every frame. The five assets from
 /// the two collections will be loaded rather quickly (one or two frames). The final task
-/// completes after three seconds. At that point `bevy_loading` will progress to the next state
+/// completes after one second. At that point, `iyes_progress` will continue to the next state
 /// and the app will terminate.
 fn main() {
     let mut app = App::new();
@@ -18,7 +18,7 @@ fn main() {
     app.add_state(MyStates::AssetLoading)
         .add_plugins(DefaultPlugins)
         // track progress during `MyStates::AssetLoading` and continue to `MyStates::Next` when progress is completed
-        .add_plugin(LoadingPlugin::new(MyStates::AssetLoading).continue_to(MyStates::Next))
+        .add_plugin(ProgressPlugin::new(MyStates::AssetLoading).continue_to(MyStates::Next))
         // gracefully quit the app when `MyStates::Next` is reached
         .add_system_set(SystemSet::on_enter(MyStates::Next).with_system(quit))
         .add_system_set(
@@ -47,7 +47,7 @@ struct TextureAssets {
 }
 
 fn track_fake_long_task(time: Res<Time>, progress: Res<ProgressCounter>) {
-    if time.seconds_since_startup() > 2. {
+    if time.seconds_since_startup() > 1. {
         info!("done");
         progress.manually_track(true.into());
     } else {

--- a/bevy_asset_loader/src/asset_loader.rs
+++ b/bevy_asset_loader/src/asset_loader.rs
@@ -25,7 +25,7 @@ use bevy_asset_ron::RonAssetPlugin;
 use dynamic_asset::DynamicAssetCollection;
 
 #[cfg(feature = "progress_tracking")]
-use bevy_loading::ProgressTracking;
+use iyes_progress::ProgressSystemLabel;
 
 pub use dynamic_asset::{DynamicAsset, DynamicAssets};
 
@@ -39,7 +39,7 @@ pub use dynamic_asset::{DynamicAsset, DynamicAssets};
 ///     let mut app = App::new();
 ///     app
 ///         .add_plugins(MinimalPlugins)
-/// #       .init_resource::<bevy_loading::ProgressCounter>()
+/// #       .init_resource::<iyes_progress::ProgressCounter>()
 ///         .add_plugin(AssetPlugin::default());
 ///     AssetLoader::new(GameState::Loading)
 ///         .continue_to_state(GameState::Menu)
@@ -109,7 +109,7 @@ where
     ///     let mut app = App::new();
     /// #   app
     /// #       .add_plugins(MinimalPlugins)
-    /// #       .init_resource::<bevy_loading::ProgressCounter>()
+    /// #       .init_resource::<iyes_progress::ProgressCounter>()
     /// #       .add_plugin(AssetPlugin::default());
     ///     AssetLoader::new(GameState::Loading)
     ///         .continue_to_state(GameState::Menu)
@@ -165,7 +165,7 @@ where
     ///     let mut app = App::new();
     /// #   app
     /// #       .add_plugins(MinimalPlugins)
-    /// #       .init_resource::<bevy_loading::ProgressCounter>()
+    /// #       .init_resource::<iyes_progress::ProgressCounter>()
     /// #       .add_plugin(AssetPlugin::default());
     ///     AssetLoader::new(GameState::Loading)
     ///         .continue_to_state(GameState::Menu)
@@ -226,7 +226,7 @@ where
     ///     let mut app = App::new();
     /// #   app
     /// #       .add_plugins(MinimalPlugins)
-    /// #       .init_resource::<bevy_loading::ProgressCounter>()
+    /// #       .init_resource::<iyes_progress::ProgressCounter>()
     /// #       .add_plugin(AssetPlugin::default());
     ///     AssetLoader::new(GameState::Loading)
     ///         .continue_to_state(GameState::Menu)
@@ -286,7 +286,7 @@ where
     ///     let mut app = App::new();
     /// #   app
     /// #       .add_plugins(MinimalPlugins)
-    /// #       .init_resource::<bevy_loading::ProgressCounter>()
+    /// #       .init_resource::<iyes_progress::ProgressCounter>()
     /// #       .add_plugin(AssetPlugin::default());
     ///     AssetLoader::new(GameState::Loading)
     ///         .continue_to_state(GameState::Menu)
@@ -341,7 +341,7 @@ where
     ///     let mut app = App::new();
     /// #   app
     /// #       .add_plugins(MinimalPlugins)
-    /// #       .init_resource::<bevy_loading::ProgressCounter>()
+    /// #       .init_resource::<iyes_progress::ProgressCounter>()
     /// #       .add_plugin(AssetPlugin::default());
     ///     AssetLoader::new(GameState::Loading)
     ///         .continue_to_state(GameState::Menu)
@@ -454,7 +454,7 @@ where
         let loading_state_system = run_loading_state::<S>
             .exclusive_system()
             .at_start()
-            .after(ProgressTracking::Preparation);
+            .after(ProgressSystemLabel::Preparation);
         #[cfg(not(feature = "progress_tracking"))]
         let loading_state_system = run_loading_state::<S>.exclusive_system().at_start();
 

--- a/bevy_asset_loader/src/asset_loader/dynamic_asset_systems.rs
+++ b/bevy_asset_loader/src/asset_loader/dynamic_asset_systems.rs
@@ -9,7 +9,7 @@ use bevy::ecs::schedule::StateData;
 #[cfg(feature = "dynamic_assets")]
 use bevy::ecs::system::SystemState;
 #[cfg(feature = "dynamic_assets")]
-use bevy::prelude::{AssetServer, Assets, Query, Res, ResMut, State, World};
+use bevy::prelude::{AssetServer, Assets, Res, ResMut, State, World};
 
 #[cfg(feature = "dynamic_assets")]
 pub(crate) fn load_dynamic_asset_collections<S: StateData>(world: &mut World) {

--- a/bevy_asset_loader/src/asset_loader/systems.rs
+++ b/bevy_asset_loader/src/asset_loader/systems.rs
@@ -7,7 +7,7 @@ use bevy::prelude::{Mut, Res, ResMut, Stage};
 use std::marker::PhantomData;
 
 #[cfg(feature = "progress_tracking")]
-use bevy_loading::{Progress, ProgressCounter};
+use iyes_progress::{Progress, ProgressCounter};
 
 use crate::asset_collection::AssetCollection;
 use crate::asset_loader::{

--- a/bevy_asset_loader/src/asset_loader/systems.rs
+++ b/bevy_asset_loader/src/asset_loader/systems.rs
@@ -2,8 +2,12 @@ use bevy::asset::{AssetServer, LoadState};
 use bevy::ecs::prelude::{FromWorld, State, World};
 use bevy::ecs::schedule::StateData;
 use bevy::ecs::system::SystemState;
+use bevy::ecs::world::WorldCell;
 use bevy::prelude::{Mut, Res, ResMut, Stage};
 use std::marker::PhantomData;
+
+#[cfg(feature = "progress_tracking")]
+use bevy_loading::{Progress, ProgressCounter};
 
 use crate::asset_collection::AssetCollection;
 use crate::asset_loader::{
@@ -38,48 +42,67 @@ pub(crate) fn start_loading_collection<S: StateData, Assets: AssetCollection>(wo
 }
 
 pub(crate) fn check_loading_collection<S: StateData, Assets: AssetCollection>(world: &mut World) {
-    {
-        let cell = world.cell();
+    if let Some((done, total)) = count_loaded_handles::<S, Assets>(world.cell()) {
+        if total == done {
+            let asset_collection = Assets::create(world);
+            world.insert_resource(asset_collection);
+            world.remove_resource::<LoadingAssetHandles<Assets>>();
 
-        let loading_asset_handles = cell.get_resource::<LoadingAssetHandles<Assets>>();
-        if loading_asset_handles.is_none() {
-            return;
-        }
-        let loading_asset_handles = loading_asset_handles.unwrap();
-
-        let asset_server = cell
-            .get_resource::<AssetServer>()
-            .expect("Cannot get AssetServer resource");
-        let load_state = asset_server
-            .get_group_load_state(loading_asset_handles.handles.iter().map(|handle| handle.id));
-        if load_state != LoadState::Loaded {
-            return;
-        }
-
-        let state = cell
-            .get_resource::<State<S>>()
-            .expect("Cannot get State resource");
-        let mut loading_state = cell
-            .get_resource_mut::<State<LoadingState>>()
-            .expect("Cannot get LoadingStatePhase");
-        let mut asset_loader_configuration = cell
-            .get_resource_mut::<AssetLoaderConfiguration<S>>()
-            .expect("Cannot get AssetLoaderConfiguration resource");
-        if let Some(mut config) = asset_loader_configuration
-            .configuration
-            .get_mut(state.current())
-        {
-            config.count -= 1;
-            if config.count == 0 {
-                loading_state
-                    .set(LoadingState::Finalize)
-                    .expect("Failed to set loading State");
-            }
+            #[cfg(feature = "progress_tracking")]
+            world
+                .resource_mut::<ProgressCounter>()
+                .persist_progress(Progress { done, total });
+        } else {
+            #[cfg(feature = "progress_tracking")]
+            world
+                .resource::<ProgressCounter>()
+                .manually_track(Progress { done, total });
         }
     }
-    let asset_collection = Assets::create(world);
-    world.insert_resource(asset_collection);
-    world.remove_resource::<LoadingAssetHandles<Assets>>();
+}
+
+fn count_loaded_handles<S: StateData, Assets: AssetCollection>(
+    cell: WorldCell,
+) -> Option<(u32, u32)> {
+    let loading_asset_handles = cell.get_resource::<LoadingAssetHandles<Assets>>()?;
+    let total = loading_asset_handles.handles.len();
+
+    let asset_server = cell
+        .get_resource::<AssetServer>()
+        .expect("Cannot get AssetServer resource");
+    let done = loading_asset_handles
+        .handles
+        .iter()
+        .map(|handle| handle.id)
+        .map(|handle_id| asset_server.get_load_state(handle_id))
+        .filter(|state| state == &LoadState::Loaded)
+        .count();
+    if done < total {
+        return Some((done as u32, total as u32));
+    }
+
+    let state = cell
+        .get_resource::<State<S>>()
+        .expect("Cannot get State resource");
+    let mut loading_state = cell
+        .get_resource_mut::<State<LoadingState>>()
+        .expect("Cannot get LoadingStatePhase");
+    let mut asset_loader_configuration = cell
+        .get_resource_mut::<AssetLoaderConfiguration<S>>()
+        .expect("Cannot get AssetLoaderConfiguration resource");
+    if let Some(mut config) = asset_loader_configuration
+        .configuration
+        .get_mut(state.current())
+    {
+        config.count -= 1;
+        if config.count == 0 {
+            loading_state
+                .set(LoadingState::Finalize)
+                .expect("Failed to set loading State");
+        }
+    }
+
+    return Some((done as u32, total as u32));
 }
 
 pub(crate) fn initialize_loading_state(mut loading_state: ResMut<State<LoadingState>>) {

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -15,6 +15,7 @@
 //!         .add_plugins(DefaultPlugins)
 //! # */
 //! #       .add_plugins(MinimalPlugins)
+//! #       .init_resource::<bevy_loading::ProgressCounter>()
 //! #       .add_plugin(AssetPlugin::default());
 //!     AssetLoader::new(GameState::Loading)
 //!         .continue_to_state(GameState::Next)

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -15,7 +15,7 @@
 //!         .add_plugins(DefaultPlugins)
 //! # */
 //! #       .add_plugins(MinimalPlugins)
-//! #       .init_resource::<bevy_loading::ProgressCounter>()
+//! #       .init_resource::<iyes_progress::ProgressCounter>()
 //! #       .add_plugin(AssetPlugin::default());
 //!     AssetLoader::new(GameState::Loading)
 //!         .continue_to_state(GameState::Next)

--- a/bevy_asset_loader/tests/can_run_without_next_state.rs
+++ b/bevy_asset_loader/tests/can_run_without_next_state.rs
@@ -6,7 +6,14 @@ use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
 use bevy_asset_loader::{AssetCollection, AssetLoader};
 
-#[cfg_attr(all(not(feature = "2d"), not(feature = "3d")), test)]
+#[cfg_attr(
+    all(
+        not(feature = "2d"),
+        not(feature = "3d"),
+        not(feature = "progress_tracking")
+    ),
+    test
+)]
 fn can_run_without_next_state() {
     let mut app = App::new();
     app.add_state(MyStates::Load)

--- a/bevy_asset_loader/tests/init_resource.rs
+++ b/bevy_asset_loader/tests/init_resource.rs
@@ -6,7 +6,14 @@ use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
 use bevy_asset_loader::{AssetCollection, AssetLoader};
 
-#[cfg_attr(all(not(feature = "2d"), not(feature = "3d")), test)]
+#[cfg_attr(
+    all(
+        not(feature = "2d"),
+        not(feature = "3d"),
+        not(feature = "progress_tracking")
+    ),
+    test
+)]
 fn init_resource() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)

--- a/bevy_asset_loader/tests/multiple_asset_collections.rs
+++ b/bevy_asset_loader/tests/multiple_asset_collections.rs
@@ -6,7 +6,14 @@ use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
 use bevy_asset_loader::{AssetCollection, AssetLoader};
 
-#[cfg_attr(all(not(feature = "2d"), not(feature = "3d")), test)]
+#[cfg_attr(
+    all(
+        not(feature = "2d"),
+        not(feature = "3d"),
+        not(feature = "progress_tracking")
+    ),
+    test
+)]
 fn multiple_asset_collections() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)


### PR DESCRIPTION
~This currently requires a custom version of `iyes_progress` (see IyesGames/iyes_progress#12).~

- [x] Use published version of `iyes_progress`
- [x] Document progress tracking setup
- [x] Document system ordering (not really from this PR, but it is good to know when the loading schedule runs)

resolves #6 