### PR TITLE
Expose resource to hold dynamic asset collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Allow adding dynamic asset collection files to a resource instead of only the Plugin builder
 - Make file endings for dynamic asset collections configurable ([#38](https://github.com/NiklasEi/bevy_asset_loader/issues/38))
 
 ## v0.10.0

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ struct ImageAssets {
 }
 ```
 
-The key `player` in the above example should be either set manually in the `DynamicAssets` resource before the loading state (see the [dynamic_asset](bevy_asset_loader/examples/dynamic_asset.rs) example), or should be part of a `.assets` file in ron format (supported file endings can be configured with `AssetLoader::set_asset_collection_file_endings`):
+The key `player` in the above example should be either set manually in the `DynamicAssets` resource before the loading state (see the [dynamic_asset](bevy_asset_loader/examples/dynamic_asset.rs) example), or should be part of a `.assets` file in ron format (supported file endings can be configured with `AssetLoader::set_dynamic_asset_collection_file_endings`):
 
 ```ron
 ({

--- a/bevy_asset_loader/examples/dynamic_asset_ron.rs
+++ b/bevy_asset_loader/examples/dynamic_asset_ron.rs
@@ -9,8 +9,10 @@ fn main() {
     app.add_plugins(DefaultPlugins);
     AssetLoader::new(MyStates::AssetLoading)
         .continue_to_state(MyStates::Next)
-        // this call can be repeated for multiple `.assets` files
-        .with_asset_collection_file("dynamic_asset_ron.assets")
+        // This call can be repeated for multiple `.assets` files
+        // You can also directly add files to the `DynamicAssetCollections<MyStates>`
+        // resource in systems running before the loading state
+        .with_dynamic_asset_collection_file("dynamic_asset_ron.assets")
         .with_collection::<ImageAssets>()
         .with_collection::<AudioAssets>()
         .build(&mut app);
@@ -25,6 +27,7 @@ fn main() {
         .run();
 }
 
+// The keys used here are defined in `assets/dynamic_asset_ron.assets`
 #[derive(AssetCollection)]
 struct ImageAssets {
     #[asset(key = "image.player")]

--- a/bevy_asset_loader/src/asset_loader.rs
+++ b/bevy_asset_loader/src/asset_loader.rs
@@ -199,7 +199,10 @@ where
     /// The file will be loaded as [`DynamicAssetCollection`](crate::dynamic_asset::DynamicAssetCollection).
     /// It's mapping of asset keys to dynamic assets will be used during the loading state to resolve asset keys.
     #[cfg(feature = "dynamic_assets")]
-    pub fn with_dynamic_asset_collection_file(mut self, dynamic_asset_collection_file: &str) -> Self {
+    pub fn with_dynamic_asset_collection_file(
+        mut self,
+        dynamic_asset_collection_file: &str,
+    ) -> Self {
         self.dynamic_asset_collections
             .push(dynamic_asset_collection_file.to_owned());
 

--- a/bevy_asset_loader/src/asset_loader/dynamic_asset.rs
+++ b/bevy_asset_loader/src/asset_loader/dynamic_asset.rs
@@ -1,7 +1,11 @@
 use bevy::utils::HashMap;
 
 #[cfg(feature = "dynamic_assets")]
+use bevy::ecs::schedule::StateData;
+#[cfg(feature = "dynamic_assets")]
 use bevy::reflect::TypeUuid;
+#[cfg(feature = "dynamic_assets")]
+use std::marker::PhantomData;
 
 /// These asset variants can be loaded from configuration files. They will then replace
 /// a dynamic asset based on their keys.
@@ -157,6 +161,27 @@ impl DynamicAssets {
     ) {
         for (key, asset) in dynamic_asset_collection.0 {
             self.key_asset_map.insert(key, asset);
+        }
+    }
+}
+
+/// Resource keeping track of dynamic asset files for different loading states
+#[cfg(feature = "dynamic_assets")]
+pub struct DynamicAssetCollections<State: StateData> {
+    /// Dynamic asset files for different loading states.
+    ///
+    /// The file lists get loaded and emptied at the beginning of the loading states.
+    /// Make sure to add any file you would like to load before entering the loading state!
+    pub files: HashMap<State, Vec<String>>,
+    pub(crate) _marker: PhantomData<State>,
+}
+
+#[cfg(feature = "dynamic_assets")]
+impl<State: StateData> Default for DynamicAssetCollections<State> {
+    fn default() -> Self {
+        DynamicAssetCollections {
+            files: HashMap::default(),
+            _marker: PhantomData::default(),
         }
     }
 }

--- a/bevy_asset_loader/src/asset_loader/dynamic_asset_systems.rs
+++ b/bevy_asset_loader/src/asset_loader/dynamic_asset_systems.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dynamic_assets")]
-use crate::asset_loader::dynamic_asset::DynamicAssetCollection;
+use crate::asset_loader::dynamic_asset::{DynamicAssetCollection, DynamicAssetCollections};
 #[cfg(feature = "dynamic_assets")]
-use crate::asset_loader::{AssetLoaderConfiguration, DynamicAssets, LoadingState};
+use crate::asset_loader::{DynamicAssets, LoadingAssetHandles, LoadingState};
 #[cfg(feature = "dynamic_assets")]
 use bevy::asset::LoadState;
 #[cfg(feature = "dynamic_assets")]
@@ -9,30 +9,39 @@ use bevy::ecs::schedule::StateData;
 #[cfg(feature = "dynamic_assets")]
 use bevy::ecs::system::SystemState;
 #[cfg(feature = "dynamic_assets")]
-use bevy::prelude::{AssetServer, Assets, Query, Res, ResMut, State, World};
+use bevy::prelude::{AssetServer, Assets, Res, ResMut, State, World};
 
 #[cfg(feature = "dynamic_assets")]
 pub(crate) fn load_dynamic_asset_collections<S: StateData>(world: &mut World) {
     let mut system_state: SystemState<(
-        ResMut<AssetLoaderConfiguration<S>>,
+        ResMut<DynamicAssetCollections<S>>,
         ResMut<State<LoadingState>>,
+        ResMut<LoadingAssetHandles<S>>,
         Res<AssetServer>,
         Res<State<S>>,
     )> = SystemState::new(world);
-    let (mut asset_loader_config, mut loading_state, asset_server, state) =
-        system_state.get_mut(world);
+    let (
+        mut dynamic_asset_collections,
+        mut loading_state,
+        mut loading_collections,
+        asset_server,
+        state,
+    ) = system_state.get_mut(world);
 
-    let files = asset_loader_config.get_asset_collection_files(state.current());
+    let files = dynamic_asset_collections
+        .files
+        .get_mut(state.current())
+        .expect("Failed to get list of dynamic asset collections for current loading state");
     if files.is_empty() {
         loading_state
             .set(LoadingState::LoadingAssets)
             .expect("Failed to set loading state");
         return;
     }
-    for file in files {
-        asset_loader_config
-            .asset_collection_handles
-            .push(asset_server.load(&file));
+    for file in files.drain(..) {
+        loading_collections
+            .handles
+            .push(asset_server.load_untyped(&file));
     }
 }
 
@@ -40,30 +49,23 @@ pub(crate) fn load_dynamic_asset_collections<S: StateData>(world: &mut World) {
 pub(crate) fn check_dynamic_asset_collections<S: StateData>(world: &mut World) {
     let mut system_state: SystemState<(
         Res<AssetServer>,
-        ResMut<AssetLoaderConfiguration<S>>,
+        ResMut<LoadingAssetHandles<S>>,
         ResMut<State<LoadingState>>,
         ResMut<Assets<DynamicAssetCollection>>,
         ResMut<DynamicAssets>,
     )> = SystemState::new(world);
     let (
         asset_server,
-        mut asset_loader_configuration,
+        mut loading_collections,
         mut loading_state,
         mut dynamic_asset_collections,
         mut asset_keys,
     ) = system_state.get_mut(world);
 
-    let collections_load_state = asset_server.get_group_load_state(
-        asset_loader_configuration
-            .asset_collection_handles
-            .iter()
-            .map(|handle| handle.id),
-    );
+    let collections_load_state = asset_server
+        .get_group_load_state(loading_collections.handles.iter().map(|handle| handle.id));
     if collections_load_state == LoadState::Loaded {
-        for collection in asset_loader_configuration
-            .asset_collection_handles
-            .drain(..)
-        {
+        for collection in loading_collections.handles.drain(..) {
             let collection = dynamic_asset_collections.remove(collection).unwrap();
             asset_keys.register_dynamic_collection(collection);
         }

--- a/bevy_asset_loader/src/asset_loader/systems.rs
+++ b/bevy_asset_loader/src/asset_loader/systems.rs
@@ -29,7 +29,7 @@ pub(crate) fn start_loading_collection<S: StateData, Assets: AssetCollection>(wo
                 state.current()
             )
         });
-    config.count += 1;
+    config.loading_collections += 1;
     let handles = LoadingAssetHandles {
         handles: Assets::load(world),
         marker: PhantomData::<Assets>,
@@ -69,8 +69,8 @@ pub(crate) fn check_loading_collection<S: StateData, Assets: AssetCollection>(wo
             .configuration
             .get_mut(state.current())
         {
-            config.count -= 1;
-            if config.count == 0 {
+            config.loading_collections -= 1;
+            if config.loading_collections == 0 {
                 loading_state
                     .set(LoadingState::Finalize)
                     .expect("Failed to set loading State");

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -68,6 +68,9 @@ mod asset_loader;
 pub use crate::asset_collection::{AssetCollection, AssetCollectionApp, AssetCollectionWorld};
 pub use crate::asset_loader::{AssetLoader, DynamicAsset, DynamicAssets};
 
+#[cfg(feature = "dynamic_assets")]
+pub use crate::asset_loader::DynamicAssetCollections;
+
 pub use bevy_asset_loader_derive::AssetCollection;
 
 #[cfg(all(feature = "2d", feature = "3d"))]


### PR DESCRIPTION
This works now:
```rust
fn setup_loading_state(mut dynamic_asset_collections: ResMut<DynamicAssetCollections<MyStates>>) {
    dynamic_asset_collections
        .files
        .get_mut(&MyStates::AssetLoading)
        .unwrap()
        .push("textures/tilesets/standard_128.assets".to_owned());
}
```