### PR TITLE
Add bevy_asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 Cargo.lock
 .idea/
+.vscode/

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -22,7 +22,7 @@ progress_tracking_stageless = ["iyes_progress/iyes_loopless"]
 stageless = ["iyes_loopless"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["bevy_asset"] }
 bevy_asset_loader_derive = { version = "=0.11.0", path = "../bevy_asset_loader_derive" }
 anyhow = "1"
 


### PR DESCRIPTION
Latest `bevy_main` failed because `bevy_asset` seems to have been moved into an explicit feature:

```
error[E0432]: unresolved import `bevy::asset`                                                                                                                                  
 --> C:\Users\Geir\.cargo\git\checkouts\bevy_asset_loader-61e45c7c12c9b28c\2e9f2a5\bevy_asset_loader\src\asset_collection.rs:3:11
  |
3 | use bevy::asset::HandleUntyped;
  |           ^^^^^ could not find `asset` in `bevy`

error[E0432]: unresolved import `bevy::asset`
 --> C:\Users\Geir\.cargo\git\checkouts\bevy_asset_loader-61e45c7c12c9b28c\2e9f2a5\bevy_asset_loader\src\dynamic_asset.rs:5:11
  |
5 | use bevy::asset::{AssetServer, HandleUntyped};
  |           ^^^^^ could not find `asset` in `bevy`
```

With adding the feature as default, the project builds.