### PR TITLE
Add failure states

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ When using `stageless` feature, you need to add `progress_tracking_stageless` fe
 
 The loading state runs in a single exclusive system `at_start`. This means that any parallel system in the loading state will always run after all asset handles have been checked for their status. You can thus read the current progress in each frame in a parallel system without worrying about frame lag.
 
+## Failure state
+
+A loading state can be configured to set a failure state if one of the assets contained in a collection fails to load. You can set failure states by calling `on_failure_continue_to` (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example).
+
+If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
+
 ## Usage without a loading state
 
 Although the pattern of a loading state is quite nice, you might have reasons not to use it. In this case `bevy_asset_loader` can still be helpful. Deriving `AssetCollection` on a resource can significantly reduce the boilerplate for managing assets.

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ The loading state runs in a single exclusive system `at_start`. This means that 
 
 ## Failure state
 
-A loading state can be configured to set a failure state if one of the assets contained in a collection fails to load. You can set failure states by calling `on_failure_continue_to` (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example).
+For the case that some asset in a collection fails to load, you can configure a failure state via `on_failure_continue_to` (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example). If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
 
-If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
+In most cases this happens, an asset file is missing, or a certain file ending does not have a corresponding asset loader. In both of these cases, a quick look into the application logs should help, since Bevy prints warnings about those issues.
 
 ## Usage without a loading state
 

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ The loading state runs in a single exclusive system `at_start`. This means that 
 
 ## Failure state
 
-For the case that some asset in a collection fails to load, you can configure a failure state via `on_failure_continue_to` (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example). If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
+You can configure a failure state in case some asset in a collection fails to load by calling `on_failure_continue_to` with a state (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example). If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
 
-In most cases this happens, an asset file is missing, or a certain file ending does not have a corresponding asset loader. In both of these cases, a quick look into the application logs should help, since Bevy prints warnings about those issues.
+In most cases this happens, an asset file is missing or a certain file ending does not have a corresponding asset loader. In both of these cases the application log should help since Bevy prints warnings about those issues.
 
 ## Usage without a loading state
 

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -82,6 +82,10 @@ path = "examples/progress_tracking.rs"
 required-features = ["progress_tracking", "2d"]
 
 [[example]]
+name = "failure_state"
+path = "examples/failure_state.rs"
+
+[[example]]
 name = "stageless"
 path = "examples/stageless.rs"
 required-features = ["stageless"]
@@ -109,6 +113,11 @@ required-features = [
   "stageless",
   "progress_tracking", "2d"
 ]
+
+[[example]]
+name = "stageless_failure_state"
+path = "examples/stageless_failure_state.rs"
+required-features = ["stageless"]
 
 [[example]]
 name = "stageless_dynamic_asset"

--- a/bevy_asset_loader/examples/failure_state.rs
+++ b/bevy_asset_loader/examples/failure_state.rs
@@ -1,0 +1,52 @@
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use bevy_asset_loader::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_loading_state(
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .on_failure_continue_to_state(MyStates::ErrorScreen)
+                .with_collection::<MyAssets>(),
+        )
+        .add_state(MyStates::AssetLoading)
+        .add_system_set(SystemSet::on_update(MyStates::AssetLoading).with_system(timeout))
+        .add_system_set(SystemSet::on_enter(MyStates::Next).with_system(fail))
+        .add_system_set(SystemSet::on_enter(MyStates::ErrorScreen).with_system(ok))
+        .run();
+}
+
+#[derive(AssetCollection)]
+struct MyAssets {
+    #[asset(path = "audio/plop.ogg")]
+    _plop: Handle<AudioSource>,
+    #[asset(path = "non-existing-file.ogg")]
+    _non_existing_file: Handle<AudioSource>,
+    #[asset(path = "audio/background.ogg")]
+    _background: Handle<AudioSource>,
+}
+
+fn fail() {
+    panic!("The library should have switched to the failure state!");
+}
+
+fn ok(mut quit: EventWriter<AppExit>) {
+    println!("As expected, the library switched to the failure state");
+    println!("Quitting the application...");
+    quit.send(AppExit);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.seconds_since_startup() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+enum MyStates {
+    AssetLoading,
+    Next,
+    ErrorScreen,
+}

--- a/bevy_asset_loader/examples/stageless_failure_state.rs
+++ b/bevy_asset_loader/examples/stageless_failure_state.rs
@@ -1,0 +1,54 @@
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use bevy_asset_loader::prelude::*;
+use iyes_loopless::prelude::*;
+
+fn main() {
+    App::new()
+        .add_loopless_state(MyStates::AssetLoading)
+        .add_plugins(DefaultPlugins)
+        .add_loading_state(
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .on_failure_continue_to_state(MyStates::ErrorScreen)
+                .with_collection::<MyAssets>(),
+        )
+        .add_state(MyStates::AssetLoading)
+        .add_system(timeout.run_in_state(MyStates::AssetLoading))
+        .add_enter_system(MyStates::Next, fail)
+        .add_enter_system(MyStates::ErrorScreen, ok)
+        .run();
+}
+
+#[derive(AssetCollection)]
+struct MyAssets {
+    #[asset(path = "audio/plop.ogg")]
+    _plop: Handle<AudioSource>,
+    #[asset(path = "non-existing-file.ogg")]
+    _non_existing_file: Handle<AudioSource>,
+    #[asset(path = "audio/background.ogg")]
+    _background: Handle<AudioSource>,
+}
+
+fn fail() {
+    panic!("The library should have switched to the failure state!");
+}
+
+fn ok(mut quit: EventWriter<AppExit>) {
+    println!("As expected, the library switched to the failure state");
+    println!("Quitting the application...");
+    quit.send(AppExit);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.seconds_since_startup() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+enum MyStates {
+    AssetLoading,
+    Next,
+    ErrorScreen,
+}

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -26,7 +26,7 @@ pub trait DynamicAsset: Debug + Send + Sync {
     fn build(&self, world: &mut World) -> Result<DynamicAssetType, anyhow::Error>;
 }
 
-/// Resource to dynamically resolve keys to asset paths.
+/// Resource to dynamically resolve keys to assets.
 ///
 /// This resource is set by a [`LoadingState`](crate::loading_state::LoadingState) and is read when entering the corresponding Bevy [`State`](::bevy::ecs::schedule::State).
 /// If you want to manage your dynamic assets manually, they should be configured in a previous [`State`](::bevy::ecs::schedule::State).

--- a/bevy_asset_loader/tests/continues_to_failure_state.rs
+++ b/bevy_asset_loader/tests/continues_to_failure_state.rs
@@ -1,0 +1,58 @@
+#![allow(dead_code, unused_imports)]
+
+use bevy::app::AppExit;
+use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
+use bevy_asset_loader::asset_collection::AssetCollection;
+use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+
+#[cfg(all(
+    not(feature = "2d"),
+    not(feature = "3d"),
+    not(feature = "progress_tracking"),
+    not(feature = "stageless")
+))]
+#[test]
+fn continues_to_failure_state() {
+    App::new()
+        .add_state(MyStates::Load)
+        .add_plugins(MinimalPlugins)
+        .add_plugin(AssetPlugin::default())
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Next)
+                .on_failure_continue_to_state(MyStates::Error)
+                .with_collection::<Audio>(),
+        )
+        .add_system_set(SystemSet::on_update(MyStates::Load).with_system(timeout))
+        .add_system_set(SystemSet::on_enter(MyStates::Next).with_system(fail))
+        .add_system_set(SystemSet::on_enter(MyStates::Error).with_system(exit))
+        .run();
+}
+
+fn fail() {
+    panic!("The library should have switched to the failure state");
+}
+
+fn exit(mut exit: EventWriter<AppExit>) {
+    exit.send(AppExit);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.seconds_since_startup() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(AssetCollection)]
+struct Audio {
+    #[asset(path = "audio/plop.ogg")]
+    no_loader_for_ogg_files: Handle<AudioSource>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+enum MyStates {
+    Load,
+    Error,
+    Next,
+}

--- a/bevy_asset_loader/tests/multiple_asset_collections.rs
+++ b/bevy_asset_loader/tests/multiple_asset_collections.rs
@@ -51,14 +51,12 @@ fn expect(
     }
 }
 
-#[allow(dead_code)]
 #[derive(AssetCollection)]
 struct PlopAudio {
     #[asset(path = "audio/plop.ogg")]
     plop: Handle<AudioSource>,
 }
 
-#[allow(dead_code)]
 #[derive(AssetCollection)]
 struct BackgroundAudio {
     #[asset(path = "audio/background.ogg")]

--- a/bevy_asset_loader/tests/stageless.rs
+++ b/bevy_asset_loader/tests/stageless.rs
@@ -6,6 +6,7 @@
 ))]
 mod stageless {
     mod can_run_without_next_state;
+    mod continues_to_failure_state;
     mod continues_without_collection;
     mod init_resource;
     mod multiple_asset_collections;

--- a/bevy_asset_loader/tests/stageless/continues_to_failure_state.rs
+++ b/bevy_asset_loader/tests/stageless/continues_to_failure_state.rs
@@ -1,0 +1,51 @@
+use bevy::app::AppExit;
+use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
+use bevy_asset_loader::asset_collection::AssetCollection;
+use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use iyes_loopless::prelude::*;
+
+#[test]
+fn continues_to_failure_state() {
+    App::new()
+        .add_loopless_state(MyStates::Load)
+        .add_plugins(MinimalPlugins)
+        .add_plugin(AssetPlugin::default())
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Next)
+                .on_failure_continue_to_state(MyStates::Error)
+                .with_collection::<Audio>(),
+        )
+        .add_system(timeout.run_in_state(MyStates::Load))
+        .add_enter_system(MyStates::Next, fail)
+        .add_enter_system(MyStates::Error, exit)
+        .run();
+}
+
+fn fail() {
+    panic!("The library should have switched to the failure state");
+}
+
+fn exit(mut exit: EventWriter<AppExit>) {
+    exit.send(AppExit);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.seconds_since_startup() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(AssetCollection)]
+struct Audio {
+    #[asset(path = "audio/plop.ogg")]
+    _no_loader_for_ogg_files: Handle<AudioSource>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+enum MyStates {
+    Load,
+    Error,
+    Next,
+}

--- a/bevy_asset_loader/tests/stageless/multiple_asset_collections.rs
+++ b/bevy_asset_loader/tests/stageless/multiple_asset_collections.rs
@@ -42,18 +42,16 @@ fn expect(
     }
 }
 
-#[allow(dead_code)]
 #[derive(AssetCollection)]
 struct PlopAudio {
     #[asset(path = "audio/plop.ogg")]
-    plop: Handle<AudioSource>,
+    _plop: Handle<AudioSource>,
 }
 
-#[allow(dead_code)]
 #[derive(AssetCollection)]
 struct BackgroundAudio {
     #[asset(path = "audio/background.ogg")]
-    background: Handle<AudioSource>,
+    _background: Handle<AudioSource>,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]


### PR DESCRIPTION
Resolves #79 

- [x] consider to also check for `NotLoaded` and `Unloaded` -> For now we only check for `Failed`. With the other two, I am afraid of race conditions. Both are valid states when the loading hasn't started yet, which happens in a separate async task after calling `load` on the asset server.