### PR TITLE
WIP: attempt upgrade to unreleased 0.9.0

### DIFF
--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -22,7 +22,7 @@ progress_tracking_stageless = ["iyes_progress/iyes_loopless"]
 stageless = ["iyes_loopless"]
 
 [dependencies]
-bevy = { version = "0.8", default-features = false, features = ["bevy_asset"] }
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "72fbcc7633248703d58f2dbf1b47cdfde945325a", default-features = false, features = ["bevy_asset"] }
 bevy_asset_loader_derive = { version = "=0.13.0", path = "../bevy_asset_loader_derive" }
 anyhow = "1"
 
@@ -32,7 +32,7 @@ iyes_progress = { version = "0.6", optional = true }
 iyes_loopless = { version = "0.8", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.8", features = ["vorbis"] }
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "72fbcc7633248703d58f2dbf1b47cdfde945325a", features = ["vorbis"] }
 anyhow = "1"
 iyes_progress = { version = "0.6" }
 iyes_loopless = { version = "0.8" }

--- a/bevy_asset_loader/src/asset_collection.rs
+++ b/bevy_asset_loader/src/asset_collection.rs
@@ -1,7 +1,7 @@
 use crate::dynamic_asset::DynamicAssets;
 use bevy::app::App;
 use bevy::asset::HandleUntyped;
-use bevy::prelude::World;
+use bevy::prelude::{World, Resource};
 
 pub use bevy_asset_loader_derive::AssetCollection;
 
@@ -19,7 +19,7 @@ pub use bevy_asset_loader_derive::AssetCollection;
 ///     tree: Handle<Image>
 /// }
 /// ```
-pub trait AssetCollection: Send + Sync + 'static {
+pub trait AssetCollection: Send + Sync + Resource + 'static {
     /// Create a new asset collection from the [`AssetServer`](::bevy::asset::AssetServer)
     fn create(world: &mut World) -> Self;
     /// Start loading all the assets in the collection
@@ -39,7 +39,7 @@ pub trait AssetCollectionApp {
 impl AssetCollectionApp for App {
     fn init_collection<Collection>(&mut self) -> &mut Self
     where
-        Collection: AssetCollection,
+        Collection: AssetCollection, 
     {
         if !self.world.contains_resource::<Collection>() {
             // This resource is required for loading a collection

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -2,6 +2,7 @@ use bevy::utils::HashMap;
 use std::any::TypeId;
 use std::fmt::Debug;
 
+use bevy::ecs::prelude::*;
 use bevy::asset::{AssetServer, HandleUntyped};
 use bevy::ecs::world::World;
 
@@ -32,7 +33,7 @@ pub trait DynamicAsset: Debug + Send + Sync {
 /// If you want to manage your dynamic assets manually, they should be configured in a previous [`State`](::bevy::ecs::schedule::State).
 ///
 /// See the `manual_dynamic_asset` example.
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct DynamicAssets {
     key_asset_map: HashMap<String, Box<dyn DynamicAsset>>,
 }
@@ -59,7 +60,7 @@ pub trait DynamicAssetCollection {
 }
 
 /// Resource keeping track of dynamic asset collection files for different loading states
-#[derive(Debug)]
+#[derive(Resource, Debug)]
 pub struct DynamicAssetCollections<State: StateData> {
     /// Dynamic asset collection files for different loading states.
     ///

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -7,6 +7,7 @@ mod systems;
 #[cfg(feature = "stageless")]
 mod stageless;
 
+use bevy::prelude::*;
 use bevy::app::App;
 #[cfg(feature = "stageless")]
 use bevy::app::CoreStage;
@@ -796,7 +797,7 @@ where
             .unwrap_or_default();
         let mut update = {
             if loading_schedule
-                .get_stage_mut::<SystemStage>(&"update")
+                .get_stage_mut::<SystemStage>("update")
                 .is_none()
             {
                 loading_schedule.add_stage("update", SystemStage::parallel());
@@ -804,7 +805,7 @@ where
                     .add_system_set_to_stage("update", State::<InternalLoadingState>::get_driver());
             }
             loading_schedule
-                .get_stage_mut::<SystemStage>(&"update")
+                .get_stage_mut::<SystemStage>("update")
                 .unwrap()
         };
 
@@ -967,13 +968,13 @@ where
             .unwrap_or_default();
         let mut update = {
             if loading_schedule
-                .get_stage_mut::<SystemStage>(&"update")
+                .get_stage_mut::<SystemStage>("update")
                 .is_none()
             {
                 loading_schedule.add_stage("update", SystemStage::parallel());
             }
             loading_schedule
-                .get_stage_mut::<SystemStage>(&"update")
+                .get_stage_mut::<SystemStage>("update")
                 .unwrap()
         };
 
@@ -1056,6 +1057,7 @@ where
 
 /// This resource is used for handles from asset collections and loading dynamic asset collection files.
 /// The generic will be the [`AssetCollection`] type for the first and the [`DynamicAssetCollection`] for the second.
+#[derive(Resource)]
 pub(crate) struct LoadingAssetHandles<T> {
     handles: Vec<HandleUntyped>,
     marker: PhantomData<T>,
@@ -1070,6 +1072,7 @@ impl<T> Default for LoadingAssetHandles<T> {
     }
 }
 
+#[derive(Resource)]
 pub(crate) struct AssetLoaderConfiguration<State: StateData> {
     state_configurations: HashMap<State, LoadingConfiguration<State>>,
 }
@@ -1117,6 +1120,7 @@ impl<State: StateData> Default for LoadingConfiguration<State> {
 }
 
 /// Resource to store the schedules for loading states
+#[derive(Resource)]
 pub struct LoadingStateSchedules<State: StateData> {
     /// Map to store a schedule per loading state
     pub schedules: HashMap<State, Schedule>,

--- a/bevy_asset_loader_derive/Cargo.toml
+++ b/bevy_asset_loader_derive/Cargo.toml
@@ -20,6 +20,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "72fbcc7633248703d58f2dbf1b47cdfde945325a", default-features = false }
 proc-macro2 = "1.0"
 syn = "1.0"
 quote = "1.0"

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -1,6 +1,7 @@
 use crate::{ParseFieldError, TextureAtlasAttribute, TEXTURE_ATLAS_ATTRIBUTE};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
+use bevy::prelude::Resource;
 
 #[derive(PartialEq, Debug)]
 pub(crate) struct TextureAtlasAssetField {
@@ -280,7 +281,7 @@ impl AssetField {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Resource, Default, Debug)]
 pub(crate) struct AssetBuilder {
     pub field_ident: Option<Ident>,
     pub asset_path: Option<String>,


### PR DESCRIPTION
- [ ] is no longer broken

I attempted to update bevy ahead of the upcoming release but was left stuck with a strange error about not being able to derive `Resource` on `AssetBuilder`. 