### PR TITLE
add support for offset in `#[asset(texture_atlas(...))]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ use bevy_asset_loader::asset_collection::AssetCollection;
 
 #[derive(AssetCollection, Resource)]
 struct MyAssets {
-    #[asset(texture_atlas(tile_size_x = 64., tile_size_y = 64., columns = 8, rows = 1, padding_x = 12., padding_y = 12.))]
+    #[asset(texture_atlas(tile_size_x = 64., tile_size_y = 64., columns = 8, rows = 1, padding_x = 12., padding_y = 12., offset_x = 6., offset_y = 6.))]
     #[asset(path = "images/sprite_sheet.png")]
     sprite: Handle<TextureAtlas>,
 }
@@ -314,11 +314,13 @@ struct MyAssets {
         rows: 1,
         padding_x: 12.,
         padding_y: 12.,
+        offset_x: 6.,
+        offset_y: 6.,
     ),
 })
 ```
 
-The two padding fields/attributes are optional and default to `0.`.
+The four padding & offset fields/attributes are optional, and default to `0.`.
 
 ### Types implementing FromWorld
 

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -22,7 +22,7 @@ fn main() {
 #[derive(AssetCollection, Resource)]
 struct MyAssets {
     // if the sheet would have padding, we could set that with `padding_x` and `padding_y`.
-    // if there's space between the top left corner of the sheet and the first sprite, we could set that `offset_x` and `offset_y`
+    // if there's space between the top left corner of the sheet and the first sprite, we could configure that with `offset_x` and `offset_y`
     #[asset(texture_atlas(tile_size_x = 96., tile_size_y = 99., columns = 8, rows = 1))]
     #[asset(path = "images/female_adventurer_sheet.png")]
     female_adventurer: Handle<TextureAtlas>,

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -21,7 +21,8 @@ fn main() {
 
 #[derive(AssetCollection, Resource)]
 struct MyAssets {
-    // if the sheet would have padding, we could set that with `padding_x` and `padding_y`
+    // if the sheet would have padding, we could set that with `padding_x` and `padding_y`.
+    // if there's space between the top left corner of the sheet and the first sprite, we could set that `offset_x` and `offset_y`
     #[asset(texture_atlas(tile_size_x = 96., tile_size_y = 99., columns = 8, rows = 1))]
     #[asset(path = "images/female_adventurer_sheet.png")]
     female_adventurer: Handle<TextureAtlas>,

--- a/bevy_asset_loader/src/standard_dynamic_asset.rs
+++ b/bevy_asset_loader/src/standard_dynamic_asset.rs
@@ -55,6 +55,10 @@ pub enum StandardDynamicAsset {
         padding_x: Option<f32>,
         /// Padding between rows in pixels
         padding_y: Option<f32>,
+        /// Number of pixels offset of the first tile
+        offset_x: Option<f32>,
+        /// Number of pixels offset of the first tile
+        offset_y: Option<f32>,
     },
 }
 
@@ -113,6 +117,8 @@ impl DynamicAsset for StandardDynamicAsset {
                 rows,
                 padding_x,
                 padding_y,
+                offset_x,
+                offset_y,
             } => {
                 let mut atlases = cell
                     .get_resource_mut::<bevy::asset::Assets<bevy::sprite::TextureAtlas>>()
@@ -124,7 +130,7 @@ impl DynamicAsset for StandardDynamicAsset {
                         *columns,
                         *rows,
                         Some(Vec2::new(padding_x.unwrap_or(0.), padding_y.unwrap_or(0.))),
-                        Some(Vec2::splat(0.)),
+                        Some(Vec2::new(offset_x.unwrap_or(0.), offset_y.unwrap_or(0.))),
                     ))
                     .clone_untyped();
 

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -603,6 +603,7 @@ mod test {
             columns: Some(10),
             rows: Some(5),
             padding_x: Some(2.),
+            offset_y: Some(3.),
             ..Default::default()
         };
 
@@ -621,7 +622,7 @@ mod test {
                 padding_x: 2.0,
                 padding_y: 0.0,
                 offset_x: 0.0,
-                offset_y: 0.0,
+                offset_y: 3.0,
             })
         );
     }
@@ -644,6 +645,10 @@ mod test {
         // Optional texture atlas field
         let mut builder = asset_builder_dynamic();
         builder.padding_y = Some(5.0);
+        assert!(builder.build().is_err());
+
+        let mut builder = asset_builder_dynamic();
+        builder.offset_x = Some(2.5);
         assert!(builder.build().is_err());
 
         let mut builder = asset_builder_dynamic();

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -12,6 +12,8 @@ pub(crate) struct TextureAtlasAssetField {
     pub rows: usize,
     pub padding_x: f32,
     pub padding_y: f32,
+    pub offset_x: f32,
+    pub offset_y: f32,
 }
 
 #[derive(PartialEq, Debug)]
@@ -120,6 +122,8 @@ impl AssetField {
                 let rows = texture_atlas.rows;
                 let padding_x = texture_atlas.padding_x;
                 let padding_y = texture_atlas.padding_y;
+                let offset_x = texture_atlas.offset_x;
+                let offset_y = texture_atlas.offset_y;
                 quote!(#token_stream #field_ident : {
                     let cell = world.cell();
                     let asset_server = cell
@@ -134,7 +138,7 @@ impl AssetField {
                         #columns,
                         #rows,
                         Some(Vec2::new(#padding_x, #padding_y)),
-                        Some(Vec2::splat(0.)),
+                        Some(Vec2::new(#offset_x, #offset_y)),
                     ))
                 },)
             }
@@ -296,6 +300,8 @@ pub(crate) struct AssetBuilder {
     pub rows: Option<usize>,
     pub padding_x: Option<f32>,
     pub padding_y: Option<f32>,
+    pub offset_x: Option<f32>,
+    pub offset_y: Option<f32>,
 }
 
 impl AssetBuilder {
@@ -338,6 +344,8 @@ impl AssetBuilder {
                 || missing_fields.len() < 4
                 || self.padding_x.is_some()
                 || self.padding_y.is_some()
+                || self.offset_x.is_some()
+                || self.offset_y.is_some()
                 || self.is_standard_material)
         {
             return Err(vec![ParseFieldError::KeyAttributeStandsAlone]);
@@ -417,6 +425,8 @@ impl AssetBuilder {
                 rows: self.rows.unwrap(),
                 padding_x: self.padding_x.unwrap_or_default(),
                 padding_y: self.padding_y.unwrap_or_default(),
+                offset_x: self.offset_x.unwrap_or_default(),
+                offset_y: self.offset_y.unwrap_or_default(),
             }));
         }
         Err(vec![ParseFieldError::MissingAttributes(missing_fields)])
@@ -609,7 +619,9 @@ mod test {
                 columns: 10,
                 rows: 5,
                 padding_x: 2.0,
-                padding_y: 0.0
+                padding_y: 0.0,
+                offset_x: 0.0,
+                offset_y: 0.0,
             })
         );
     }

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -47,6 +47,10 @@ impl TextureAtlasAttribute {
     pub const PADDING_X: &'static str = "padding_x";
     #[allow(dead_code)]
     pub const PADDING_Y: &'static str = "padding_y";
+    #[allow(dead_code)]
+    pub const OFFSET_X: &'static str = "offset_x";
+    #[allow(dead_code)]
+    pub const OFFSET_Y: &'static str = "offset_y";
 }
 
 pub(crate) const COLLECTION_ATTRIBUTE: &str = "collection";
@@ -345,6 +349,26 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                     if let Lit::Float(padding_y) = &named_value.lit {
                                         builder.padding_y =
                                             Some(padding_y.base10_parse::<f32>().unwrap());
+                                    } else {
+                                        errors.push(ParseFieldError::WrongAttributeType(
+                                            named_value.into_token_stream(),
+                                            "float",
+                                        ));
+                                    }
+                                } else if path == TextureAtlasAttribute::OFFSET_X {
+                                    if let Lit::Float(offset_x) = &named_value.lit {
+                                        builder.offset_x =
+                                            Some(offset_x.base10_parse::<f32>().unwrap());
+                                    } else {
+                                        errors.push(ParseFieldError::WrongAttributeType(
+                                            named_value.into_token_stream(),
+                                            "float",
+                                        ));
+                                    }
+                                } else if path == TextureAtlasAttribute::OFFSET_Y {
+                                    if let Lit::Float(offset_y) = &named_value.lit {
+                                        builder.offset_y =
+                                            Some(offset_y.base10_parse::<f32>().unwrap());
                                     } else {
                                         errors.push(ParseFieldError::WrongAttributeType(
                                             named_value.into_token_stream(),


### PR DESCRIPTION
Seems like access to this parameter was missing, with a default `Some(Vec2::splat(0.))` given instead of any way to access the value. Hope this helps!