### PR TITLE
Replace unmaintained actions-rs/toolchain action in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
       - uses: taiki-e/install-action@v1
         with:
           tool: cargo-hack
@@ -51,10 +50,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
       - uses: taiki-e/install-action@v1
         with:
           tool: cargo-hack
@@ -76,11 +74,10 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ubuntu-latest-cargo-build-stable-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           components: rustfmt, clippy
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run clippy


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/NiklasEi/bevy_asset_loader/actions/runs/4772933949:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).