### PR TITLE
add DynamicAssets::iter_assets method

### DIFF
--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -43,6 +43,11 @@ impl DynamicAssets {
         self.key_asset_map.get(key).map(|boxed| boxed.as_ref())
     }
 
+    /// Iterate over all the known key→asset mappings
+    pub fn iter_assets(&self) -> impl Iterator<Item = (&str, &dyn DynamicAsset)> {
+        self.key_asset_map.iter().map(|(k, v)| (k.as_str(), v.as_ref()))
+    }
+
     /// Set the corresponding dynamic asset for the given key.
     ///
     /// In case the key is already known, its value will be overwritten.


### PR DESCRIPTION
In my project I want to iterate over the entire set of dynamic assets that `bevy_asset_loader` has detected and filter that iterator to load different assets based on the string key.

There was no way to iterate over all dynamic assets, only to lookup/get a specific one. This PR addresses this omission. :)