### PR TITLE
Support vectors of dynamic assets in dynamic asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ use bevy_asset_loader::asset_collection::AssetCollection;
 
 #[derive(AssetCollection, Resource)]
 struct MyAssets {
-    #[asset(key = "files_untyped", collection)]
+    #[asset(key = "files", collection)]
     files_untyped: Vec<HandleUntyped>,
-    #[asset(key = "files_typed", collection(typed))]
+    #[asset(key = "files", collection(typed))]
     files_typed: Vec<Handle<Image>>,
 }
 ```
@@ -248,12 +248,10 @@ struct MyAssets {
 The corresponding assets file differs from the folder example:
 ```ron
 ({
-    "files_untyped": Files (
-        paths: ["images/tree.png", "images/player.png"],
-    ),
-    "files_typed": Files (
-        paths: ["images/tree.png", "images/player.png"],
-    ),
+    "files": [
+        File(path: "images/tree.png"),
+        File(path: "images/player.png"),
+    ],
 })
 ```
 

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 2d = ["bevy/bevy_sprite", "bevy_asset_loader_derive/2d"]
 # This feature adds support for bevy's StandardMaterial assets
 3d = ["bevy/bevy_pbr", "bevy/bevy_render", "bevy_asset_loader_derive/3d"]
-standard_dynamic_assets = ["dep:bevy_common_assets", "dep:serde"]
+standard_dynamic_assets = ["dep:bevy_common_assets"]
 progress_tracking = ["dep:iyes_progress"]
 
 [dependencies]
@@ -26,7 +26,7 @@ anyhow = "1"
 path-slash = "0.2"
 
 bevy_common_assets = { path = "../../bevy_common_assets", version = "0.7.0", features = ["ron"], optional = true }
-serde = { version = "1", optional = true }
+serde = { version = "1" }
 iyes_progress = { version = "0.9.0", optional = true }
 
 [dev-dependencies]

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -25,7 +25,7 @@ bevy_asset_loader_derive = { version = "=0.17.0", path = "../bevy_asset_loader_d
 anyhow = "1"
 path-slash = "0.2"
 
-bevy_common_assets = { version = "0.7.0", features = ["ron"], optional = true }
+bevy_common_assets = { path = "../../bevy_common_assets", version = "0.7.0", features = ["ron"], optional = true }
 serde = { version = "1", optional = true }
 iyes_progress = { version = "0.9.0", optional = true }
 
@@ -33,7 +33,7 @@ iyes_progress = { version = "0.9.0", optional = true }
 bevy = { version = "0.11", features = ["vorbis"] }
 anyhow = "1"
 iyes_progress = { version = "0.9.0" }
-bevy_common_assets = { version = "0.7.0", features = ["ron"] }
+bevy_common_assets = { path = "../../bevy_common_assets", version = "0.7.0", features = ["ron"] }
 serde = { version = "1" }
 trybuild = { version = "1.0" }
 
@@ -95,3 +95,4 @@ required-features = ["2d", "3d", "standard_dynamic_assets"]
 [[example]]
 name = "custom_dynamic_assets"
 path = "examples/custom_dynamic_assets.rs"
+required-features = ["2d", "standard_dynamic_assets"]

--- a/bevy_asset_loader/assets/custom.my-assets.ron
+++ b/bevy_asset_loader/assets/custom.my-assets.ron
@@ -11,6 +11,14 @@
         bottom_layer: "images/tree.png",
         top_layer: "images/player.png",
     ),
+    "tree": File(path: "images/tree.png"),
+    "images": [
+        CombinedImage (
+            bottom_layer: "images/tree.png",
+            top_layer: "images/player.png",
+        ),
+        File(path: "images/player.png")
+    ],
     "cube": Cube (
         size: 1.3,
     ),

--- a/bevy_asset_loader/assets/dynamic_asset.assets.ron
+++ b/bevy_asset_loader/assets/dynamic_asset.assets.ron
@@ -12,4 +12,8 @@
     "sounds.background": File (
         path: "audio/background.ogg",
     ),
+    "images": [
+        File(path: "images/tree.png"),
+        File(path: "images/player.png")
+    ],
 })

--- a/bevy_asset_loader/examples/dynamic_asset.rs
+++ b/bevy_asset_loader/examples/dynamic_asset.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_loading_state(
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
+        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAsset>(
             MyStates::AssetLoading,
             "dynamic_asset.assets.ron",
         )
@@ -36,6 +36,8 @@ struct ImageAssets {
     player: Handle<TextureAtlas>,
     #[asset(key = "image.tree")]
     tree: Handle<Image>,
+    #[asset(key = "images", collection(typed))]
+    images: Vec<Handle<Image>>,
 }
 
 #[derive(AssetCollection, Resource)]
@@ -46,8 +48,6 @@ struct AudioAssets {
 
 fn spawn_player_and_tree(mut commands: Commands, image_assets: Res<ImageAssets>) {
     commands.spawn(Camera2dBundle::default());
-    let mut transform = Transform::from_translation(Vec3::new(0., 0., 1.));
-    transform.scale = Vec3::splat(0.5);
     commands
         .spawn(SpriteSheetBundle {
             transform: Transform {
@@ -65,9 +65,21 @@ fn spawn_player_and_tree(mut commands: Commands, image_assets: Res<ImageAssets>)
         .insert(Player);
     commands.spawn(SpriteBundle {
         texture: image_assets.tree.clone(),
-        transform: Transform::from_translation(Vec3::new(50., 30., 1.)),
+        transform: Transform::from_translation(Vec3::new(0., 30., 1.)),
         ..Default::default()
     });
+
+    for (index, image) in image_assets.images.iter().enumerate() {
+        commands.spawn(SpriteBundle {
+            texture: image.clone(),
+            transform: Transform::from_translation(Vec3::new(
+                -50. + 100. * index as f32,
+                -100.,
+                1.,
+            )),
+            ..Default::default()
+        });
+    }
 }
 
 fn play_background_audio(mut commands: Commands, audio_assets: Res<AudioAssets>) {

--- a/bevy_asset_loader/examples/full_dynamic_collection.rs
+++ b/bevy_asset_loader/examples/full_dynamic_collection.rs
@@ -16,7 +16,7 @@ fn main() {
         .add_loading_state(
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
+        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAsset>(
             MyStates::AssetLoading,
             "full_dynamic_collection.assets.ron",
         )

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -82,9 +82,7 @@ pub mod standard_dynamic_asset;
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "standard_dynamic_assets")]
-    pub use crate::standard_dynamic_asset::{
-        RegisterStandardDynamicAsset, StandardDynamicAsset, StandardDynamicAssetCollection,
-    };
+    pub use crate::standard_dynamic_asset::{RegisterStandardDynamicAsset, StandardDynamicAsset};
     #[doc(hidden)]
     pub use crate::{
         asset_collection::{AssetCollection, AssetCollectionApp, AssetCollectionWorld},

--- a/bevy_asset_loader/src/standard_dynamic_asset.rs
+++ b/bevy_asset_loader/src/standard_dynamic_asset.rs
@@ -5,13 +5,13 @@ use bevy::ecs::world::World;
 #[cfg(feature = "2d")]
 use bevy::math::Vec2;
 
-use crate::dynamic_asset::{DynamicAssetCollection, DynamicAssets};
+use crate::dynamic_asset::DynamicAssets;
 use bevy::reflect::{TypePath, TypeUuid};
-use bevy::utils::HashMap;
 
 /// These asset variants can be loaded from configuration files. They will then replace
 /// a dynamic asset based on their keys.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(serde::Deserialize, Debug, Clone, TypeUuid, TypePath)]
+#[uuid = "ffd1c91b-1d97-4af0-a0c9-9767a5f4e168"]
 pub enum StandardDynamicAsset {
     /// A dynamic asset directly loaded from a single file
     File {
@@ -163,21 +163,5 @@ impl<K: Into<String> + Sync + Send + 'static> Command for RegisterStandardDynami
     fn apply(self, world: &mut World) {
         let mut dynamic_assets = world.resource_mut::<DynamicAssets>();
         dynamic_assets.register_asset(self.key, Box::new(self.asset));
-    }
-}
-
-/// The asset defining a mapping from asset keys to dynamic assets
-///
-/// These assets are loaded at the beginning of a loading state
-/// and combined in [`DynamicAssets`](DynamicAssets).
-#[derive(serde::Deserialize, TypeUuid, TypePath)]
-#[uuid = "2df82c01-9c71-4aa8-adc4-71c5824768f1"]
-pub struct StandardDynamicAssetCollection(pub HashMap<String, StandardDynamicAsset>);
-
-impl DynamicAssetCollection for StandardDynamicAssetCollection {
-    fn register(&self, dynamic_assets: &mut DynamicAssets) {
-        for (key, asset) in self.0.iter() {
-            dynamic_assets.register_asset(key, Box::new(asset.clone()));
-        }
     }
 }

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -243,138 +243,139 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
         for attribute in asset_meta_list.unwrap() {
             match attribute {
                 Meta::List(meta_list) if meta_list.path.is_ident(TEXTURE_ATLAS_ATTRIBUTE) => {
-                    let texture_atlas_meta_list =
-                        meta_list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated);
                     #[cfg(not(feature = "2d"))]
                     errors.push(ParseFieldError::Missing2dFeature(
                         meta_list.into_token_stream(),
                     ));
-                    #[cfg(feature = "2d")]
-                    for attribute in texture_atlas_meta_list.unwrap() {
-                        match attribute {
-                            Meta::NameValue(named_value) => {
-                                let path = named_value.path.get_ident().unwrap().clone();
-                                if path == TextureAtlasAttribute::TILE_SIZE_X {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(width),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.tile_size_x =
-                                            Some(width.base10_parse::<f32>().unwrap());
+                    #[cfg(feature = "2d")] {
+                        let texture_atlas_meta_list =
+                            meta_list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated);
+                        for attribute in texture_atlas_meta_list.unwrap() {
+                            match attribute {
+                                Meta::NameValue(named_value) => {
+                                    let path = named_value.path.get_ident().unwrap().clone();
+                                    if path == TextureAtlasAttribute::TILE_SIZE_X {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(width),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.tile_size_x =
+                                                Some(width.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::TILE_SIZE_Y {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(height),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.tile_size_y =
+                                                Some(height.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::COLUMNS {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Int(columns),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.columns =
+                                                Some(columns.base10_parse::<usize>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "integer",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::ROWS {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Int(rows),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.rows = Some(rows.base10_parse::<usize>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "integer",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::PADDING_X {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(padding_x),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.padding_x =
+                                                Some(padding_x.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::PADDING_Y {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(padding_y),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.padding_y =
+                                                Some(padding_y.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::OFFSET_X {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(offset_x),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.offset_x =
+                                                Some(offset_x.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
+                                    } else if path == TextureAtlasAttribute::OFFSET_Y {
+                                        if let Expr::Lit(ExprLit {
+                                                             lit: Lit::Float(offset_y),
+                                                             ..
+                                                         }) = &named_value.value
+                                        {
+                                            builder.offset_y =
+                                                Some(offset_y.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float",
+                                            ));
+                                        }
                                     } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
+                                        errors.push(ParseFieldError::UnknownAttribute(
                                             named_value.into_token_stream(),
-                                            "float",
                                         ));
                                     }
-                                } else if path == TextureAtlasAttribute::TILE_SIZE_Y {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(height),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.tile_size_y =
-                                            Some(height.base10_parse::<f32>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "float",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::COLUMNS {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Int(columns),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.columns =
-                                            Some(columns.base10_parse::<usize>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "integer",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::ROWS {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Int(rows),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.rows = Some(rows.base10_parse::<usize>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "integer",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::PADDING_X {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(padding_x),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.padding_x =
-                                            Some(padding_x.base10_parse::<f32>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "float",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::PADDING_Y {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(padding_y),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.padding_y =
-                                            Some(padding_y.base10_parse::<f32>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "float",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::OFFSET_X {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(offset_x),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.offset_x =
-                                            Some(offset_x.base10_parse::<f32>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "float",
-                                        ));
-                                    }
-                                } else if path == TextureAtlasAttribute::OFFSET_Y {
-                                    if let Expr::Lit(ExprLit {
-                                        lit: Lit::Float(offset_y),
-                                        ..
-                                    }) = &named_value.value
-                                    {
-                                        builder.offset_y =
-                                            Some(offset_y.base10_parse::<f32>().unwrap());
-                                    } else {
-                                        errors.push(ParseFieldError::WrongAttributeType(
-                                            named_value.into_token_stream(),
-                                            "float",
-                                        ));
-                                    }
-                                } else {
-                                    errors.push(ParseFieldError::UnknownAttribute(
-                                        named_value.into_token_stream(),
+                                }
+                                _ => {
+                                    errors.push(ParseFieldError::UnknownAttributeType(
+                                        attribute.into_token_stream(),
                                     ));
                                 }
-                            }
-                            _ => {
-                                errors.push(ParseFieldError::UnknownAttributeType(
-                                    attribute.into_token_stream(),
-                                ));
                             }
                         }
                     }


### PR DESCRIPTION
This allows for dynamic asset files like
```ron
({
    "files": [
        File(path: "images/tree.png"),
        File(path: "images/player.png"),
    ],
})
```
and even works for custom dynamic assets and nested collections
```ron
({
    "images": [
        CombinedImage (
            bottom_layer: "images/tree.png",
            top_layer: "images/player.png",
        ),
        [
            File(path: "images/tree.png"),
            File(path: "images/player.png"),
        ],
        Folder(path: "images")
    ],
})
```

ToDo

- [ ] Update `ron` when the new version is published ron-rs/ron#496
- [ ] Simplify/double-check trait bounds
- [ ] Remove `StandardDynamicAsset::Files` in preference of defining vecs in the asset files?
- [ ] Make `OneOrManyDynamicAssets` optional
    - [ ] Maybe move the asset wrapper type to a trait as an associated type?
    - [ ] Write a test to ensure users can add custom dynamic assets without it
- [ ] Introduce a new feature for dynamic assets to hide serde behind it?
    - [ ] Check if bevy_asset doesn't already require serde. 

Resolves #78 
