### PR TITLE
Fixed broken links in Readme and rust docs warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ enum GameState {
 }
 ```
 
-The [full_collection](bevy_asset_loader/examples/full_collection.rs) example showcases all the different kinds of fields that an asset collection can contain using only derive macro attributes.
+The [full_collection](/bevy_asset_loader/examples/full_collection.rs) example showcases all the different kinds of fields that an asset collection can contain using only derive macro attributes.
 
 ### Dynamic assets
 
@@ -93,7 +93,9 @@ struct ImageAssets {
 }
 ```
 
-The keys `player` and `tree` in the example above should either be set manually in the `DynamicAssets` resource prior to the loading state (see the [manual_dynamic_asset](bevy_asset_loader/examples/manual_dynamic_asset.rs) example), or be part of a dynamic assets file (see [dynamic_asset](bevy_asset_loader/examples/dynamic_asset.rs)). A dynamic assets file for the collection above might look like this:
+The keys `player` and `tree` in the example above should either be set manually in the `DynamicAssets` resource prior to the loading state 
+(see the [manual_dynamic_asset](/bevy_asset_loader/examples/manual_dynamic_asset.rs) example), or be part of a dynamic assets file (see [dynamic_asset](/bevy_asset_loader/examples/dynamic_asset.rs)). 
+A dynamic assets file for the collection above might look like this:
 ```ron
 ({
     "player": File (
@@ -111,11 +113,11 @@ The file ending is `.assets.ron` by default, but can be configured via `LoadingS
 
 Dynamic assets can be optional. This requires the derive attribute `optional` on the field and the type to be an `Option`. The value of the field will be `None` in case the given key cannot be resolved at run time.
 
-The example [full_dynamic_collection](bevy_asset_loader/examples/full_dynamic_collection.rs) shows all supported field types for dynamic assets. Note that adding a dynamic asset file to a loading state requires the `AssetServer` resource to be available. In most cases that means that you should add the `DefaultPlugins` before configuring your loading state.
+The example [full_dynamic_collection](/bevy_asset_loader/examples/full_dynamic_collection.rs) shows all supported field types for dynamic assets. Note that adding a dynamic asset file to a loading state requires the `AssetServer` resource to be available. In most cases that means that you should add the `DefaultPlugins` before configuring your loading state.
 
 ### Custom dynamic assets
 
-You can define your own types to load as dynamic assets. Take a look at the [custom_dynamic_assets.rs](bevy_asset_loader/examples/custom_dynamic_assets.rs) example for some code.
+You can define your own types to load as dynamic assets. Take a look at the [custom_dynamic_assets.rs](/bevy_asset_loader/examples/custom_dynamic_assets.rs) example for some code.
 
 ## Supported asset fields
 
@@ -311,7 +313,7 @@ The corresponding dynamic asset would be
 
 ### Standard materials
 
-You can directly load standard materials if you enable the feature `3d`. For a complete example please take a look at [standard_material.rs](bevy_asset_loader/examples/standard_material.rs).
+You can directly load standard materials if you enable the feature `3d`. For a complete example please take a look at [standard_material.rs](/bevy_asset_loader/examples/standard_material.rs).
 
 ```rust
 use bevy::prelude::*;
@@ -343,7 +345,7 @@ struct MyAssets {
 
 ### Texture atlases
 
-You can directly load texture atlases from sprite sheets if you enable the feature `2d`. For a complete example please take a look at [atlas_from_grid.rs](bevy_asset_loader/examples/atlas_from_grid.rs).
+You can directly load texture atlases from sprite sheets if you enable the feature `2d`. For a complete example please take a look at [atlas_from_grid.rs](/bevy_asset_loader/examples/atlas_from_grid.rs).
 
 ```rust
 use bevy::prelude::*;
@@ -389,7 +391,7 @@ Any field in an asset collection without any attribute is required to implement 
 
 ## Initializing FromWorld resources
 
-In situations where you would like to prepare other resources based on your loaded asset collections you can use `App::init_resource_after_loading_state` to initialize `FromWorld` resources. See [init_resource.rs](bevy_asset_loader/examples/init_resource.rs) for an example that loads two images and then combines their pixel data into a third image.
+In situations where you would like to prepare other resources based on your loaded asset collections you can use `App::init_resource_after_loading_state` to initialize `FromWorld` resources. See [init_resource.rs](/bevy_asset_loader/examples/init_resource.rs) for an example that loads two images and then combines their pixel data into a third image.
 
 `App::init_resource_after_loading_state` does the same as Bevy's `App::init_resource`, but at a different point in time. While Bevy inserts your resources at the very beginning, `bevy_asset_loader` will initialize them only after your loaded asset collections are inserted. That means you can use your asset collections in the `FromWorld` implementation.
 
@@ -397,7 +399,7 @@ In situations where you would like to prepare other resources based on your load
 
 With the feature `progress_tracking`, you can integrate with [`iyes_progress`][iyes_progress] to track asset loading during a loading state. This, for example, enables progress bars.
 
-See [`progress_tracking`](bevy_asset_loader/examples/progress_tracking.rs) for a complete example.
+See [`progress_tracking`](/bevy_asset_loader/examples/progress_tracking.rs) for a complete example.
 
 ### A note on system ordering
 
@@ -405,7 +407,7 @@ The loading state is organized in a private schedule that runs in a single syste
 
 ## Failure state
 
-You can configure a failure state in case some asset in a collection fails to load by calling `on_failure_continue_to` with a state (see [`failure_state`](bevy_asset_loader/examples/failure_state.rs) example). If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
+You can configure a failure state in case some asset in a collection fails to load by calling `on_failure_continue_to` with a state (see [`failure_state`](/bevy_asset_loader/examples/failure_state.rs) example). If no failure state is configured and some asset fails to load, your application will be stuck in the loading state.
 
 In most cases this happens, an asset file is missing or a certain file ending does not have a corresponding asset loader. In both of these cases the application log should help since Bevy prints warnings about those issues.
 
@@ -415,7 +417,7 @@ Although the pattern of a loading state is quite nice (imo), you might have reas
 
 Asset collections loaded without a loading state do not support folders or dynamic assets, since these cannot instantly create handles that will eventually point to the loaded assets.
 
-You can directly initialise asset collections on the bevy `App` or `World`. See [no_loading_state.rs](bevy_asset_loader/examples/no_loading_state.rs) for a complete example.
+You can directly initialise asset collections on the bevy `App` or `World`. See [no_loading_state.rs](/bevy_asset_loader/examples/no_loading_state.rs) for a complete example.
 
 ```rust no_run
 use bevy::prelude::*;
@@ -467,7 +469,7 @@ Dual-licensed under either of
 
 at your option.
 
-Assets in the examples might be distributed under different terms. See the [readme](bevy_asset_loader/examples/README.md#credits) in the `bevy_asset_loader/examples` directory.
+Assets in the examples might be distributed under different terms. See the [readme](/bevy_asset_loader/examples/README.md#credits) in the `bevy_asset_loader/examples` directory.
 
 ## Contribution
 

--- a/bevy_asset_loader/src/asset_collection.rs
+++ b/bevy_asset_loader/src/asset_collection.rs
@@ -27,9 +27,9 @@ pub trait AssetCollection: Resource {
     fn load(world: &mut World) -> Vec<UntypedHandle>;
 }
 
-/// Extension trait for [`App`](::bevy::app::App) enabling initialisation of [asset collections](crate::asset_collection::AssetCollection)
+/// Extension trait for [`App`] enabling initialisation of [asset collections](crate::asset_collection::AssetCollection)
 pub trait AssetCollectionApp {
-    /// Initialise an [`AssetCollection`](crate::asset_collection::AssetCollection)
+    /// Initialise an [`AssetCollection`]
     ///
     /// This function does not give any guaranties about the loading status of the asset handles.
     /// If you want to use a loading state, you do not need this function! Instead use an [`LoadingState`](crate::loading_state::LoadingState)
@@ -56,7 +56,7 @@ impl AssetCollectionApp for App {
     }
 }
 
-/// Extension trait for [`World`](::bevy::ecs::world::World) enabling initialisation of [asset collections](AssetCollection)
+/// Extension trait for [`World`] enabling initialisation of [asset collections](AssetCollection)
 pub trait AssetCollectionWorld {
     /// Initialise an [`AssetCollection`]
     ///

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -29,8 +29,8 @@ pub trait DynamicAsset: Debug + Send + Sync {
 
 /// Resource to dynamically resolve keys to assets.
 ///
-/// This resource is set by a [`LoadingState`](crate::loading_state::LoadingState) and is read when entering the corresponding Bevy [`State`](State).
-/// If you want to manage your dynamic assets manually, they should be configured in a previous [`State`](State).
+/// This resource is set by a [`LoadingState`](crate::loading_state::LoadingState) and is read when entering the corresponding Bevy [`State`](::bevy::ecs::schedule::State).
+/// If you want to manage your dynamic assets manually, they should be configured in a previous [`State`](::bevy::ecs::schedule::State).
 ///
 /// See the `manual_dynamic_asset` example.
 #[derive(Resource, Default)]

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -158,7 +158,7 @@ where
         }
     }
 
-    /// The [`LoadingState`] will set this Bevy [`State`](State) after all asset collections
+    /// The [`LoadingState`] will set this Bevy [`State`] after all asset collections
     /// are loaded and inserted as resources.
     /// ```edition2021
     /// # use bevy_asset_loader::prelude::*;
@@ -204,7 +204,7 @@ where
         self
     }
 
-    /// The [`LoadingState`] will set this Bevy [`State`](State) if an asset fails to load.
+    /// The [`LoadingState`] will set this Bevy [`State`] if an asset fails to load.
     /// ```edition2021
     /// # use bevy_asset_loader::prelude::*;
     /// # use bevy::prelude::*;
@@ -443,7 +443,7 @@ where
     }
 }
 
-///  Systems in this set check the loading state of assets and will change the [`InternalLoadingState`] accordingly.
+///  Systems in this set check the loading state of assets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub struct LoadingStateSet<S: States>(pub S);
 

--- a/bevy_asset_loader/src/standard_dynamic_asset.rs
+++ b/bevy_asset_loader/src/standard_dynamic_asset.rs
@@ -271,7 +271,7 @@ impl<K: Into<String> + Sync + Send + 'static> Command for RegisterStandardDynami
 /// The asset defining a mapping from asset keys to dynamic assets
 ///
 /// These assets are loaded at the beginning of a loading state
-/// and combined in [`DynamicAssets`](DynamicAssets).
+/// and combined in [`DynamicAssets`].
 #[derive(serde::Deserialize, Asset, TypePath)]
 pub struct StandardDynamicAssetCollection(pub HashMap<String, StandardDynamicAsset>);
 


### PR DESCRIPTION
# Changes

- Fixed warnings previously emitted by command cargo doc.
- Fixed some spelling.
- Fixed a few links for Github in README by prefixing them with a leading "/". Without those leading slashes the links produce a file not found aka 404 error.

## Note

In file [bevy_asset_loader/src/dynamic_asset.rs](https://github.com/NiklasEi/bevy_asset_loader/compare/main...BoolPurist:bevy_asset_loader:fix_broken_links?expand=1#diff-ada8b879b8055d65e1b25aa4222cecf031c6260019409dc6ccc3b075648bbede) at line 446 I replaced the link to struct which is only visible within the crate, with just the word state. This change fixes a warning produced by the command:
```sh
cargo doc --all-features
```
and prevents leaking an inner detail which is not relevant to an user of the crate.