### PR TITLE
API changes to simplify configuration of a loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- New API to add and configure loading states
+  - Less API surface on Bevy's App type and fewer generics
+    - Only two methods on the App: `add_loading_state` and `configure_loading_state`
+  - The old API is still supported, but deprecated for easier migration 
+
 ## v0.18.0 - 08.11.2023
 - update to Bevy 0.12
 - Make `loading_state::LoadingStateSet` public for explicit system ordering

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,15 @@
 [workspace]
+rust-version = "1.74.0"
 resolver = "2"
 members = [
     "bevy_asset_loader",
     "bevy_asset_loader_derive"
 ]
+
+[workspace.lints.clippy]
+doc_markdown = "warn"
+redundant_else = "warn"
+match_same_arms = "warn"
+semicolon_if_nothing_returned = "warn"
+map_flatten = "warn"
+manual_let_else = "warn"

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -102,3 +102,8 @@ path = "examples/custom_dynamic_assets.rs"
 name = "image_asset"
 path = "examples/image_asset.rs"
 required-features = ["2d"]
+
+[[example]]
+name = "configure_loading_state"
+path = "examples/configure_loading_state.rs"
+required-features = ["2d"]

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -42,6 +42,9 @@ trybuild = { version = "1.0" }
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[lints]
+workspace = true
+
 [[example]]
 name = "two_collections"
 path = "examples/two_collections.rs"

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_asset_loader::loading_state::LoadingStateConfig;
 use bevy_asset_loader::prelude::*;
 
 /// This example demonstrates how to load a texture atlas from a sprite sheet
@@ -11,7 +12,9 @@ fn main() {
         .add_loading_state(
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
+        .configure_loading_state(
+            LoadingStateConfig::new(MyStates::AssetLoading).with_collection::<MyAssets>(),
+        )
         .add_systems(OnEnter(MyStates::Next), draw_atlas)
         .add_systems(
             Update,

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -13,7 +13,7 @@ fn main() {
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
         .configure_loading_state(
-            LoadingStateConfig::new(MyStates::AssetLoading).add_collection::<MyAssets>(),
+            LoadingStateConfig::new(MyStates::AssetLoading).load_collection::<MyAssets>(),
         )
         .add_systems(OnEnter(MyStates::Next), draw_atlas)
         .add_systems(

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -67,9 +67,9 @@ struct AnimationTimer(Timer);
 
 fn animate_sprite_system(
     time: Res<Time>,
-    mut query: Query<(&mut AnimationTimer, &mut TextureAtlasSprite)>,
+    mut sprites_to_animate: Query<(&mut AnimationTimer, &mut TextureAtlasSprite)>,
 ) {
-    for (mut timer, mut sprite) in &mut query {
+    for (mut timer, mut sprite) in &mut sprites_to_animate {
         timer.0.tick(time.delta());
         if timer.0.finished() {
             sprite.index = (sprite.index + 1) % 8;

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_asset_loader::loading_state::LoadingStateConfig;
 use bevy_asset_loader::prelude::*;
 
 /// This example demonstrates how to load a texture atlas from a sprite sheet
@@ -10,10 +9,9 @@ fn main() {
         .add_state::<MyStates>()
         .add_plugins(DefaultPlugins)
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
-        )
-        .configure_loading_state(
-            LoadingStateConfig::new(MyStates::AssetLoading).load_collection::<MyAssets>(),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<MyAssets>(),
         )
         .add_systems(OnEnter(MyStates::Next), draw_atlas)
         .add_systems(

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -13,7 +13,7 @@ fn main() {
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
         .configure_loading_state(
-            LoadingStateConfig::new(MyStates::AssetLoading).with_collection::<MyAssets>(),
+            LoadingStateConfig::new(MyStates::AssetLoading).add_collection::<MyAssets>(),
         )
         .add_systems(OnEnter(MyStates::Next), draw_atlas)
         .add_systems(

--- a/bevy_asset_loader/examples/configure_loading_state.rs
+++ b/bevy_asset_loader/examples/configure_loading_state.rs
@@ -13,6 +13,9 @@ struct MainPlugin;
 impl Plugin for MainPlugin {
     fn build(&self, app: &mut App) {
         app.add_state::<MyStates>()
+            // General loading state setup goes here, but if you like, you can already add all
+            // the configuration at this point, too. In this example we will configure the loading state
+            // later in PlayerAndMusicPlugin.
             .add_loading_state(
                 LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
             )
@@ -28,7 +31,8 @@ struct PlayerAndMusicPlugin;
 impl Plugin for PlayerAndMusicPlugin {
     fn build(&self, app: &mut App) {
         app
-            // We can add all kinds of things to the loading state here. This method can be called from any plugin any number of times.
+            // We can add all kinds of things to the loading state here. This method can be called
+            // from any plugin any number of times.
             .configure_loading_state(
                 LoadingStateConfig::new(MyStates::AssetLoading)
                     .load_collection::<AudioAssets>()

--- a/bevy_asset_loader/examples/configure_loading_state.rs
+++ b/bevy_asset_loader/examples/configure_loading_state.rs
@@ -1,0 +1,83 @@
+use bevy::prelude::*;
+use bevy_asset_loader::prelude::*;
+
+/// This example demonstrates how to configure an existing loading state from a separate plugin
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, MainPlugin, PlayerAndMusicPlugin))
+        .run();
+}
+
+struct MainPlugin;
+
+impl Plugin for MainPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_state::<MyStates>()
+            .add_loading_state(
+                LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            )
+            .add_systems(
+                OnEnter(MyStates::Next),
+                (spawn_player, play_background_audio),
+            );
+    }
+}
+
+struct PlayerAndMusicPlugin;
+
+impl Plugin for PlayerAndMusicPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            // We can add all kinds of things to the loading state here. This method can be called from any plugin any number of times.
+            .configure_loading_state(
+                LoadingStateConfig::new(MyStates::AssetLoading)
+                    .add_collection::<AudioAssets>()
+                    .add_collection::<ImageAssets>()
+                    .init_resource::<ExampleResource>(),
+            );
+    }
+}
+
+#[derive(AssetCollection, Resource)]
+struct AudioAssets {
+    #[asset(path = "audio/background.ogg")]
+    background: Handle<AudioSource>,
+}
+
+#[derive(AssetCollection, Resource)]
+struct ImageAssets {
+    #[asset(path = "images/player.png")]
+    player: Handle<Image>,
+}
+
+#[derive(Resource)]
+struct ExampleResource(&'static str);
+
+impl FromWorld for ExampleResource {
+    fn from_world(_world: &mut World) -> Self {
+        ExampleResource("You could use the ECS World here!")
+    }
+}
+
+fn spawn_player(mut commands: Commands, image_assets: Res<ImageAssets>) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(SpriteBundle {
+        texture: image_assets.player.clone(),
+        transform: Transform::from_translation(Vec3::new(0., 0., 1.)),
+        ..Default::default()
+    });
+}
+
+fn play_background_audio(mut commands: Commands, audio_assets: Res<AudioAssets>) {
+    commands.spawn(AudioBundle {
+        source: audio_assets.background.clone(),
+        settings: PlaybackSettings::LOOP,
+    });
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Default, States)]
+enum MyStates {
+    #[default]
+    AssetLoading,
+    Next,
+}

--- a/bevy_asset_loader/examples/configure_loading_state.rs
+++ b/bevy_asset_loader/examples/configure_loading_state.rs
@@ -31,8 +31,8 @@ impl Plugin for PlayerAndMusicPlugin {
             // We can add all kinds of things to the loading state here. This method can be called from any plugin any number of times.
             .configure_loading_state(
                 LoadingStateConfig::new(MyStates::AssetLoading)
-                    .add_collection::<AudioAssets>()
-                    .add_collection::<ImageAssets>()
+                    .load_collection::<AudioAssets>()
+                    .load_collection::<ImageAssets>()
                     .init_resource::<ExampleResource>(),
             );
     }

--- a/bevy_asset_loader/examples/custom_dynamic_assets.rs
+++ b/bevy_asset_loader/examples/custom_dynamic_assets.rs
@@ -14,16 +14,12 @@ fn main() {
         // We need to make sure that our dynamic asset collections can be loaded from the asset file
         .add_state::<MyStates>()
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<MyAssets>()
+                .register_dynamic_asset_collection::<CustomDynamicAssetCollection>()
+                .with_dynamic_assets_file::<CustomDynamicAssetCollection>("custom.my-assets.ron"),
         )
-        .register_dynamic_asset_collection::<_, CustomDynamicAssetCollection>(
-            MyStates::AssetLoading,
-        )
-        .add_dynamic_collection_to_loading_state::<_, CustomDynamicAssetCollection>(
-            MyStates::AssetLoading,
-            "custom.my-assets.ron",
-        )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
         .add_systems(OnEnter(MyStates::Next), render_stuff)
         .run();
 }

--- a/bevy_asset_loader/examples/dynamic_asset.rs
+++ b/bevy_asset_loader/examples/dynamic_asset.rs
@@ -9,14 +9,14 @@ fn main() {
         .add_state::<MyStates>()
         .add_plugins(DefaultPlugins)
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .with_dynamic_assets_file::<StandardDynamicAssetCollection>(
+                    "dynamic_asset.assets.ron",
+                )
+                .load_collection::<ImageAssets>()
+                .load_collection::<AudioAssets>(),
         )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
-            MyStates::AssetLoading,
-            "dynamic_asset.assets.ron",
-        )
-        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
-        .add_collection_to_loading_state::<_, AudioAssets>(MyStates::AssetLoading)
         .add_systems(
             OnEnter(MyStates::Next),
             (spawn_player_and_tree, play_background_audio),

--- a/bevy_asset_loader/examples/failure_state.rs
+++ b/bevy_asset_loader/examples/failure_state.rs
@@ -9,9 +9,9 @@ fn main() {
         .add_loading_state(
             LoadingState::new(MyStates::AssetLoading)
                 .continue_to_state(MyStates::Next)
-                .on_failure_continue_to_state(MyStates::ErrorScreen),
+                .on_failure_continue_to_state(MyStates::ErrorScreen)
+                .load_collection::<MyAssets>(),
         )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
         .add_systems(Update, timeout.run_if(in_state(MyStates::AssetLoading)))
         .add_systems(OnEnter(MyStates::Next), fail)
         .add_systems(OnEnter(MyStates::ErrorScreen), ok)

--- a/bevy_asset_loader/examples/full_collection.rs
+++ b/bevy_asset_loader/examples/full_collection.rs
@@ -10,9 +10,10 @@ fn main() {
         .add_state::<MyStates>()
         .add_plugins(DefaultPlugins)
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<MyAssets>(),
         )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
         .add_systems(OnEnter(MyStates::Next), expectations)
         .run();
 }

--- a/bevy_asset_loader/examples/full_dynamic_collection.rs
+++ b/bevy_asset_loader/examples/full_dynamic_collection.rs
@@ -14,13 +14,13 @@ fn main() {
         .add_state::<MyStates>()
         .add_plugins(DefaultPlugins)
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .with_dynamic_assets_file::<StandardDynamicAssetCollection>(
+                    "full_dynamic_collection.assets.ron",
+                )
+                .load_collection::<MyAssets>(),
         )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
-            MyStates::AssetLoading,
-            "full_dynamic_collection.assets.ron",
-        )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
         .add_systems(Update, expectations.run_if(in_state(MyStates::Next)))
         .run();
 }

--- a/bevy_asset_loader/examples/image_asset.rs
+++ b/bevy_asset_loader/examples/image_asset.rs
@@ -7,9 +7,10 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<MyStates>()
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<ImageAssets>(),
         )
-        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
         .add_systems(OnEnter(MyStates::Next), draw)
         .run();
 }

--- a/bevy_asset_loader/examples/init_resource.rs
+++ b/bevy_asset_loader/examples/init_resource.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy_asset_loader::loading_state::LoadingStateConfig;
 use bevy_asset_loader::prelude::*;
 
 /// This example demonstrates how you can use [`App::init_resource_after_loading_state`] to initialize
@@ -13,8 +14,11 @@ fn main() {
         .add_loading_state(
             LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
         )
-        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
-        .init_resource_after_loading_state::<_, CombinedImage>(MyStates::AssetLoading)
+        .configure_loading_state(
+            LoadingStateConfig::new(MyStates::AssetLoading)
+                .add_collection::<ImageAssets>()
+                .init_resource::<CombinedImage>(),
+        )
         .add_systems(OnEnter(MyStates::Next), draw)
         .run();
 }

--- a/bevy_asset_loader/examples/init_resource.rs
+++ b/bevy_asset_loader/examples/init_resource.rs
@@ -1,9 +1,9 @@
 use bevy::prelude::*;
-use bevy_asset_loader::loading_state::LoadingStateConfig;
 use bevy_asset_loader::prelude::*;
 
-/// This example demonstrates how you can use [`App::init_resource_after_loading_state`] to initialize
+/// This example demonstrates how you can use [`LoadingState::init_resource`] to initialize
 /// assets implementing [`FromWorld`] after your collections are inserted into the ECS.
+/// The same is possible with [`LoadingStateConfig::init_resource`] from anywhere in your Bevy application
 ///
 /// In this showcase we load two images in an [`AssetCollection`] and then combine
 /// them by adding up their pixel data.
@@ -12,10 +12,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<MyStates>()
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
-        )
-        .configure_loading_state(
-            LoadingStateConfig::new(MyStates::AssetLoading)
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
                 .load_collection::<ImageAssets>()
                 .init_resource::<CombinedImage>(),
         )

--- a/bevy_asset_loader/examples/init_resource.rs
+++ b/bevy_asset_loader/examples/init_resource.rs
@@ -16,7 +16,7 @@ fn main() {
         )
         .configure_loading_state(
             LoadingStateConfig::new(MyStates::AssetLoading)
-                .add_collection::<ImageAssets>()
+                .load_collection::<ImageAssets>()
                 .init_resource::<CombinedImage>(),
         )
         .add_systems(OnEnter(MyStates::Next), draw)

--- a/bevy_asset_loader/examples/manual_dynamic_asset.rs
+++ b/bevy_asset_loader/examples/manual_dynamic_asset.rs
@@ -10,17 +10,19 @@ fn main() {
         .add_state::<MyStates>()
         .add_plugins(DefaultPlugins)
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                // This collection has a dynamic asset where the file path is resolved at run time
+                // and one optional image asset for the background.
+                // => see the ImageAssets definition below
+                .load_collection::<ImageAssets>()
+                .load_collection::<AudioAssets>(),
         )
-        // This collection has a dynamic asset where the file path is resolved at run time
-        // and one optional image asset for the background.
-        // => see the ImageAssets definition below
-        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
-        .add_collection_to_loading_state::<_, AudioAssets>(MyStates::AssetLoading)
         .add_loading_state(
-            LoadingState::new(MyStates::MenuAssetLoading).continue_to_state(MyStates::Menu),
+            LoadingState::new(MyStates::MenuAssetLoading)
+                .continue_to_state(MyStates::Menu)
+                .load_collection::<FontAssets>(),
         )
-        .add_collection_to_loading_state::<_, FontAssets>(MyStates::MenuAssetLoading)
         .insert_resource(ShowBackground(false))
         .add_systems(
             OnEnter(MyStates::Next),

--- a/bevy_asset_loader/examples/manual_dynamic_asset.rs
+++ b/bevy_asset_loader/examples/manual_dynamic_asset.rs
@@ -255,7 +255,7 @@ fn update_menu(
             .value = format!(
             "Background is {}",
             if show_background.0 { "On" } else { "Off" }
-        )
+        );
     }
 }
 

--- a/bevy_asset_loader/examples/progress_tracking.rs
+++ b/bevy_asset_loader/examples/progress_tracking.rs
@@ -20,9 +20,11 @@ fn main() {
             FrameTimeDiagnosticsPlugin,
         ))
         .add_state::<MyStates>()
-        .add_loading_state(LoadingState::new(MyStates::AssetLoading))
-        .add_collection_to_loading_state::<_, TextureAssets>(MyStates::AssetLoading)
-        .add_collection_to_loading_state::<_, AudioAssets>(MyStates::AssetLoading)
+        .add_loading_state(
+            LoadingState::new(MyStates::AssetLoading)
+                .load_collection::<TextureAssets>()
+                .load_collection::<AudioAssets>(),
+        )
         // gracefully quit the app when `MyStates::Next` is reached
         .add_systems(OnEnter(MyStates::Next), expect)
         .add_systems(

--- a/bevy_asset_loader/examples/standard_material.rs
+++ b/bevy_asset_loader/examples/standard_material.rs
@@ -9,9 +9,10 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<MyStates>()
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<MyAssets>(),
         )
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::AssetLoading)
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 0.2,

--- a/bevy_asset_loader/examples/two_collections.rs
+++ b/bevy_asset_loader/examples/two_collections.rs
@@ -9,10 +9,11 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_state::<MyStates>()
         .add_loading_state(
-            LoadingState::new(MyStates::AssetLoading).continue_to_state(MyStates::Next),
+            LoadingState::new(MyStates::AssetLoading)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<ImageAssets>()
+                .load_collection::<AudioAssets>(),
         )
-        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
-        .add_collection_to_loading_state::<_, AudioAssets>(MyStates::AssetLoading)
         .add_systems(
             OnEnter(MyStates::Next),
             (spawn_player_and_tree, play_background_audio),

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -85,7 +85,29 @@ impl<State: States> DynamicAssetCollections<State> {
         self.register_file_by_type_id(loading_state, file, TypeId::of::<C>());
     }
 
-    fn register_file_by_type_id(&mut self, loading_state: State, file: &str, type_id: TypeId) {
+    pub(crate) fn register_files_by_type_id(
+        &mut self,
+        loading_state: State,
+        mut files: Vec<String>,
+        type_id: TypeId,
+    ) {
+        let mut dynamic_collections_for_state =
+            self.files.remove(&loading_state).unwrap_or_default();
+        let mut dynamic_files = dynamic_collections_for_state
+            .remove(&type_id)
+            .unwrap_or_default();
+        dynamic_files.append(&mut files);
+        dynamic_collections_for_state.insert(type_id, dynamic_files);
+        self.files
+            .insert(loading_state, dynamic_collections_for_state);
+    }
+
+    pub(crate) fn register_file_by_type_id(
+        &mut self,
+        loading_state: State,
+        file: &str,
+        type_id: TypeId,
+    ) {
         let mut dynamic_collections_for_state =
             self.files.remove(&loading_state).unwrap_or_default();
         let mut dynamic_files = dynamic_collections_for_state

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -82,13 +82,17 @@ impl<State: States> DynamicAssetCollections<State> {
         loading_state: State,
         file: &str,
     ) {
+        self.register_file_by_type_id(loading_state, file, TypeId::of::<C>());
+    }
+
+    fn register_file_by_type_id(&mut self, loading_state: State, file: &str, type_id: TypeId) {
         let mut dynamic_collections_for_state =
             self.files.remove(&loading_state).unwrap_or_default();
         let mut dynamic_files = dynamic_collections_for_state
-            .remove(&TypeId::of::<C>())
+            .remove(&type_id)
             .unwrap_or_default();
         dynamic_files.push(file.to_owned());
-        dynamic_collections_for_state.insert(TypeId::of::<C>(), dynamic_files);
+        dynamic_collections_for_state.insert(type_id, dynamic_files);
         self.files
             .insert(loading_state, dynamic_collections_for_state);
     }

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -20,9 +20,9 @@
 //!         .add_loading_state(
 //!             LoadingState::new(GameState::Loading)
 //!                 .continue_to_state(GameState::Next)
+//!                 .load_collection::<AudioAssets>()
+//!                 .load_collection::<ImageAssets>()
 //!         )
-//!         .add_collection_to_loading_state::<_, AudioAssets>(GameState::Loading)
-//!         .add_collection_to_loading_state::<_, ImageAssets>(GameState::Loading)
 //!         .add_systems(Update, use_asset_handles.run_if(in_state(GameState::Next)))
 //! #       .set_runner(|mut app| app.update())
 //!         .run();
@@ -81,6 +81,8 @@ pub mod standard_dynamic_asset;
 /// Most commonly used types
 pub mod prelude {
     #[doc(hidden)]
+    pub use crate::loading_state::config::{ConfigureLoadingState, LoadingStateConfig};
+    #[doc(hidden)]
     #[cfg(feature = "standard_dynamic_assets")]
     pub use crate::standard_dynamic_asset::{
         RegisterStandardDynamicAsset, StandardDynamicAsset, StandardDynamicAssetCollection,
@@ -92,10 +94,7 @@ pub mod prelude {
             DynamicAsset, DynamicAssetCollection, DynamicAssetCollections, DynamicAssetType,
             DynamicAssets,
         },
-        loading_state::{
-            ConfigureLoadingState, LoadingState, LoadingStateAppExt, LoadingStateConfig,
-            LoadingStateSet,
-        },
+        loading_state::{LoadingState, LoadingStateAppExt, LoadingStateSet},
     };
 }
 

--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -92,7 +92,10 @@ pub mod prelude {
             DynamicAsset, DynamicAssetCollection, DynamicAssetCollections, DynamicAssetType,
             DynamicAssets,
         },
-        loading_state::{LoadingState, LoadingStateAppExt, LoadingStateSet},
+        loading_state::{
+            ConfigureLoadingState, LoadingState, LoadingStateAppExt, LoadingStateConfig,
+            LoadingStateSet,
+        },
     };
 }
 

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -417,9 +417,11 @@ where
                 );
 
             #[cfg(feature = "standard_dynamic_assets")]
-            app.register_dynamic_asset_collection::<_, StandardDynamicAssetCollection>(
-                self.loading_state.clone(),
-            );
+            {
+                self.config = self
+                    .config
+                    .register_dynamic_asset_collection::<StandardDynamicAssetCollection>();
+            }
 
             #[cfg(feature = "progress_tracking")]
             app.add_systems(
@@ -598,9 +600,9 @@ pub trait LoadingStateAppExt {
     ///         .add_loading_state(
     ///           LoadingState::new(GameState::Loading)
     ///             .continue_to_state(GameState::Menu)
+    ///             .load_collection::<AudioAssets>()
+    ///             .load_collection::<ImageAssets>()
     ///         )
-    ///         .add_collection_to_loading_state::<_, AudioAssets>(GameState::Loading)
-    ///         .add_collection_to_loading_state::<_, ImageAssets>(GameState::Loading)
     /// #       .set_runner(|mut app| app.update())
     /// #       .run();
     /// # }
@@ -625,7 +627,7 @@ pub trait LoadingStateAppExt {
     /// ```
     #[deprecated(
         since = "0.19.0",
-        note = "Use load_collection on LoadingState or LoadingStateConfig instead."
+        note = "Use `LoadingStateConfig::load_collection` or `LoadingState::load_collection` instead."
     )]
     fn add_collection_to_loading_state<S: States, A: AssetCollection>(
         &mut self,
@@ -638,7 +640,7 @@ pub trait LoadingStateAppExt {
     /// your own dynamic asset collection types.
     #[deprecated(
         since = "0.19.0",
-        note = "Use configure_loading_state and [`LoadingStateConfig::register_dynamic_asset_collection`] instead."
+        note = "Use `LoadingStateConfig::register_dynamic_asset_collection` or `LoadingState::register_dynamic_asset_collection` instead."
     )]
     fn register_dynamic_asset_collection<S: States, C: DynamicAssetCollection + Asset>(
         &mut self,
@@ -655,7 +657,7 @@ pub trait LoadingStateAppExt {
     /// If you want to see some code, take a look at the `custom_dynamic_assets` example.
     #[deprecated(
         since = "0.19.0",
-        note = "Use configure_loading_state and [`LoadingStateConfig::with_dynamic_assets`] instead."
+        note = "Use `LoadingState::with_dynamic_assets_file` or `LoadingStateConfig::with_dynamic_assets_file` instead."
     )]
     fn add_dynamic_collection_to_loading_state<S: States, C: DynamicAssetCollection + Asset>(
         &mut self,
@@ -710,7 +712,7 @@ pub trait LoadingStateAppExt {
     /// ```
     #[deprecated(
         since = "0.19.0",
-        note = "Use configure_loading_state and [`LoadingStateConfig::init_resource`] instead."
+        note = "Use `LoadingState::init_resource` or `LoadingStateConfig::init_resource` instead."
     )]
     fn init_resource_after_loading_state<S: States, A: Resource + FromWorld>(
         &mut self,
@@ -765,6 +767,7 @@ pub struct LoadingStateConfig<S: States> {
     dynamic_assets: HashMap<TypeId, Vec<String>>,
 }
 
+/// Methods to configure a loading state
 pub trait ConfigureLoadingState {
     /// Add the given collection to the loading state.
     ///
@@ -797,6 +800,7 @@ pub trait ConfigureLoadingState {
 }
 
 impl<S: States> LoadingStateConfig<S> {
+    /// Create a new configuration for the given loading state
     pub fn new(state: S) -> Self {
         Self {
             state,

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -846,7 +846,7 @@ impl<S: States> LoadingStateConfig<S> {
             .world
             .get_resource_mut::<DynamicAssetCollections<S>>()
             .unwrap_or_else(|| {
-                panic!("Failed to get the DynamicAssetCollections resource for the loading state.")
+                panic!("Failed to get the DynamicAssetCollections resource for the loading state. Are you trying to configure a loading state before it was added to the bevy App?")
             });
         for (id, files) in self.dynamic_assets.drain() {
             dynamic_assets.register_files_by_type_id(self.state.clone(), files, id);

--- a/bevy_asset_loader/src/loading_state/config.rs
+++ b/bevy_asset_loader/src/loading_state/config.rs
@@ -1,0 +1,194 @@
+use crate::asset_collection::AssetCollection;
+use crate::dynamic_asset::{DynamicAssetCollection, DynamicAssetCollections};
+use crate::loading_state::dynamic_asset_systems::{
+    check_dynamic_asset_collections, load_dynamic_asset_collections,
+};
+use crate::loading_state::systems::{
+    check_loading_collection, init_resource, start_loading_collection,
+};
+use crate::loading_state::{
+    InternalLoadingState, InternalLoadingStateSet, LoadingStateSchedule,
+    OnEnterInternalLoadingState,
+};
+use bevy::app::App;
+use bevy::asset::Asset;
+use bevy::ecs::schedule::SystemConfigs;
+use bevy::prelude::{default, FromWorld, IntoSystemConfigs, Resource, States};
+use bevy::utils::HashMap;
+use std::any::TypeId;
+
+/// Methods to configure a loading state
+pub trait ConfigureLoadingState {
+    /// Add the given collection to the loading state.
+    ///
+    /// Its loading progress will be tracked. Only when all included handles are fully loaded, the
+    /// collection will be inserted to the ECS as a resource.
+    ///
+    /// See the `two_collections` example
+    #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
+    fn load_collection<A: AssetCollection>(self) -> Self;
+
+    /// The resource will be initialized at the end of the loading state using its [`FromWorld`] implementation.
+    /// All asset collections will be available at that point and fully loaded.
+    ///
+    /// See the `init_resource` example
+    #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
+    fn init_resource<R: Resource + FromWorld>(self) -> Self;
+
+    /// Register a custom dynamic asset collection type
+    ///
+    /// See the `custom_dynamic_assets` example
+    #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
+    fn register_dynamic_asset_collection<C: DynamicAssetCollection + Asset>(self) -> Self;
+
+    /// Add a file containing dynamic assets to the loading state. Keys contained in the file, will
+    /// be available for asset collections.
+    ///
+    /// See the `dynamic_asset` example
+    #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
+    fn with_dynamic_assets_file<C: DynamicAssetCollection + Asset>(self, file: &str) -> Self;
+}
+
+/// Can be used to add new asset collections or similar configuration to a loading state.
+/// ```edition2021
+/// # use bevy_asset_loader::prelude::*;
+/// # use bevy::prelude::*;
+/// # use bevy::asset::AssetPlugin;
+/// # fn main() {
+///     App::new()
+/// # /*
+///         .add_plugins(DefaultPlugins)
+/// # */
+/// #       .add_plugins((MinimalPlugins, AssetPlugin::default()))
+///         .add_state::<GameState>()
+/// #       .init_resource::<iyes_progress::ProgressCounter>()
+///         .add_loading_state(
+///           LoadingState::new(GameState::Loading)
+///             .continue_to_state(GameState::Menu)
+///         )
+///         .configure_loading_state(LoadingStateConfig::new(GameState::Loading).load_collection::<AudioAssets>())
+/// #       .set_runner(|mut app| app.update())
+///         .run();
+/// # }
+///
+/// # #[derive(Clone, Eq, PartialEq, Debug, Hash, Default, States)]
+/// # enum GameState {
+/// #     #[default]
+/// #     Loading,
+/// #     Menu
+/// # }
+/// # #[derive(AssetCollection, Resource)]
+/// # struct AudioAssets {
+/// #     #[asset(path = "audio/background.ogg")]
+/// #     background: Handle<AudioSource>,
+/// #     #[asset(path = "audio/plop.ogg")]
+/// #     plop: Handle<AudioSource>
+/// # }
+/// ```
+pub struct LoadingStateConfig<S: States> {
+    state: S,
+
+    on_enter_loading_assets: Vec<SystemConfigs>,
+    on_enter_loading_dynamic_asset_collections: Vec<SystemConfigs>,
+    on_update: Vec<SystemConfigs>,
+    on_enter_finalize: Vec<SystemConfigs>,
+
+    dynamic_assets: HashMap<TypeId, Vec<String>>,
+}
+
+impl<S: States> LoadingStateConfig<S> {
+    /// Create a new configuration for the given loading state
+    pub fn new(state: S) -> Self {
+        Self {
+            state,
+            on_enter_loading_assets: vec![],
+            on_enter_loading_dynamic_asset_collections: vec![],
+            on_update: vec![],
+            on_enter_finalize: vec![],
+            dynamic_assets: default(),
+        }
+    }
+
+    pub(crate) fn with_dynamic_assets_type_id(&mut self, file: &str, type_id: TypeId) {
+        let mut dynamic_files = self.dynamic_assets.remove(&type_id).unwrap_or_default();
+        dynamic_files.push(file.to_owned());
+        self.dynamic_assets.insert(type_id, dynamic_files);
+    }
+
+    pub(crate) fn build(mut self, app: &mut App) {
+        for config in self.on_enter_loading_assets {
+            app.add_systems(
+                OnEnterInternalLoadingState(
+                    self.state.clone(),
+                    InternalLoadingState::LoadingAssets,
+                ),
+                config,
+            );
+        }
+        for config in self.on_update {
+            app.add_systems(LoadingStateSchedule(self.state.clone()), config);
+        }
+        for config in self.on_enter_finalize {
+            app.add_systems(
+                OnEnterInternalLoadingState(self.state.clone(), InternalLoadingState::Finalize),
+                config,
+            );
+        }
+        for config in self.on_enter_loading_dynamic_asset_collections {
+            app.add_systems(
+                OnEnterInternalLoadingState(
+                    self.state.clone(),
+                    InternalLoadingState::LoadingDynamicAssetCollections,
+                ),
+                config,
+            );
+        }
+        let mut dynamic_assets = app
+            .world
+            .get_resource_mut::<DynamicAssetCollections<S>>()
+            .unwrap_or_else(|| {
+                panic!("Failed to get the DynamicAssetCollections resource for the loading state. Are you trying to configure a loading state before it was added to the bevy App?")
+            });
+        for (id, files) in self.dynamic_assets.drain() {
+            dynamic_assets.register_files_by_type_id(self.state.clone(), files, id);
+        }
+    }
+}
+
+impl<S: States> ConfigureLoadingState for LoadingStateConfig<S> {
+    fn load_collection<A: AssetCollection>(mut self) -> Self {
+        self.on_enter_loading_assets
+            .push(start_loading_collection::<S, A>.into_configs());
+        self.on_update.push(
+            check_loading_collection::<S, A>
+                .in_set(InternalLoadingStateSet::CheckAssets)
+                .into_configs(),
+        );
+
+        self
+    }
+
+    fn init_resource<R: Resource + FromWorld>(mut self) -> Self {
+        self.on_enter_finalize
+            .push(init_resource::<R>.into_configs());
+
+        self
+    }
+
+    fn register_dynamic_asset_collection<C: DynamicAssetCollection + Asset>(mut self) -> Self {
+        self.on_enter_loading_dynamic_asset_collections
+            .push(load_dynamic_asset_collections::<S, C>.into_configs());
+        self.on_update.push(
+            check_dynamic_asset_collections::<S, C>
+                .in_set(InternalLoadingStateSet::CheckDynamicAssetCollections),
+        );
+
+        self
+    }
+
+    fn with_dynamic_assets_file<C: DynamicAssetCollection + Asset>(mut self, file: &str) -> Self {
+        self.with_dynamic_assets_type_id(file, TypeId::of::<C>());
+
+        self
+    }
+}

--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -110,7 +110,7 @@ fn count_loaded_handles<S: States, Assets: AssetCollection>(cell: WorldCell) -> 
             config.loading_collections -= 1;
         }
     } else {
-        warn!("Failed to read loading state configuration in count_loaded_handles")
+        warn!("Failed to read loading state configuration in count_loaded_handles");
     }
 
     Some((done as u32, total as u32))
@@ -134,7 +134,7 @@ pub(crate) fn resume_to_finalize<S: States>(
             next_user_state.set(failure);
         }
     } else {
-        warn!("Failed to read loading state configuration in resume_to_finalize")
+        warn!("Failed to read loading state configuration in resume_to_finalize");
     }
 }
 

--- a/bevy_asset_loader/tests/can_run_without_next_state.rs
+++ b/bevy_asset_loader/tests/can_run_without_next_state.rs
@@ -4,8 +4,7 @@ use bevy::app::AppExit;
 use bevy::asset::AssetPlugin;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -21,8 +20,7 @@ fn can_run_without_next_state() {
             AssetPlugin::default(),
             AudioPlugin::default(),
         ))
-        .add_loading_state(LoadingState::new(MyStates::Load))
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::Load)
+        .add_loading_state(LoadingState::new(MyStates::Load).load_collection::<MyAssets>())
         .init_resource::<TestState>()
         .add_systems(
             Update,

--- a/bevy_asset_loader/tests/continues_to_failure_state.rs
+++ b/bevy_asset_loader/tests/continues_to_failure_state.rs
@@ -3,8 +3,7 @@
 use bevy::app::AppExit;
 use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -19,9 +18,9 @@ fn continues_to_failure_state() {
         .add_loading_state(
             LoadingState::new(MyStates::Load)
                 .continue_to_state(MyStates::Next)
-                .on_failure_continue_to_state(MyStates::Error),
+                .on_failure_continue_to_state(MyStates::Error)
+                .load_collection::<Audio>(),
         )
-        .add_collection_to_loading_state::<_, Audio>(MyStates::Load)
         .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
         .add_systems(OnEnter(MyStates::Next), fail)
         .add_systems(OnEnter(MyStates::Error), exit)

--- a/bevy_asset_loader/tests/continues_without_collection.rs
+++ b/bevy_asset_loader/tests/continues_without_collection.rs
@@ -3,7 +3,7 @@
 use bevy::app::AppExit;
 use bevy::asset::AssetPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),

--- a/bevy_asset_loader/tests/init_resource.rs
+++ b/bevy_asset_loader/tests/init_resource.rs
@@ -4,8 +4,7 @@ use bevy::app::AppExit;
 use bevy::asset::AssetPlugin;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -21,9 +20,12 @@ fn init_resource() {
             AssetPlugin::default(),
             AudioPlugin::default(),
         ))
-        .add_loading_state(LoadingState::new(MyStates::Load).continue_to_state(MyStates::Next))
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::Load)
-        .init_resource_after_loading_state::<_, PostProcessed>(MyStates::Load)
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<MyAssets>()
+                .init_resource::<PostProcessed>(),
+        )
         .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
         .add_systems(OnEnter(MyStates::Next), expect)
         .run();

--- a/bevy_asset_loader/tests/mapped_path_use_slash.rs
+++ b/bevy_asset_loader/tests/mapped_path_use_slash.rs
@@ -5,8 +5,7 @@ use bevy::asset::AssetPlugin;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
 use bevy::utils::HashMap;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -22,8 +21,11 @@ fn mapped_path_use_slash() {
             AssetPlugin::default(),
             AudioPlugin::default(),
         ))
-        .add_loading_state(LoadingState::new(MyStates::Load).continue_to_state(MyStates::Next))
-        .add_collection_to_loading_state::<_, AudioCollection>(MyStates::Load)
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<AudioCollection>(),
+        )
         .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
         .add_systems(OnEnter(MyStates::Next), expect)
         .run();

--- a/bevy_asset_loader/tests/multiple_asset_collections.rs
+++ b/bevy_asset_loader/tests/multiple_asset_collections.rs
@@ -4,8 +4,7 @@ use bevy::app::AppExit;
 use bevy::asset::AssetPlugin;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -21,9 +20,12 @@ fn multiple_asset_collections() {
             AssetPlugin::default(),
             AudioPlugin::default(),
         ))
-        .add_loading_state(LoadingState::new(MyStates::Load).continue_to_state(MyStates::Next))
-        .add_collection_to_loading_state::<_, PlopAudio>(MyStates::Load)
-        .add_collection_to_loading_state::<_, BackgroundAudio>(MyStates::Load)
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Next)
+                .load_collection::<PlopAudio>()
+                .load_collection::<BackgroundAudio>(),
+        )
         .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
         .add_systems(OnEnter(MyStates::Next), expect)
         .run();

--- a/bevy_asset_loader/tests/multiple_loading_states.rs
+++ b/bevy_asset_loader/tests/multiple_loading_states.rs
@@ -3,8 +3,7 @@
 use bevy::app::AppExit;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::asset_collection::AssetCollection;
-use bevy_asset_loader::loading_state::{LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -20,11 +19,17 @@ fn multiple_loading_states() {
             AssetPlugin::default(),
             AudioPlugin::default(),
         ))
-        .add_loading_state(LoadingState::new(MyStates::Splash).continue_to_state(MyStates::Load))
-        .add_collection_to_loading_state::<_, SplashAssets>(MyStates::Splash)
-        .add_loading_state(LoadingState::new(MyStates::Load).continue_to_state(MyStates::Play))
-        .add_collection_to_loading_state::<_, MyAssets>(MyStates::Load)
-        .add_collection_to_loading_state::<_, MyOtherAssets>(MyStates::Load)
+        .add_loading_state(
+            LoadingState::new(MyStates::Splash)
+                .continue_to_state(MyStates::Load)
+                .load_collection::<SplashAssets>(),
+        )
+        .add_loading_state(
+            LoadingState::new(MyStates::Load)
+                .continue_to_state(MyStates::Play)
+                .load_collection::<MyAssets>()
+                .load_collection::<MyOtherAssets>(),
+        )
         .add_systems(Update, (quit.run_if(in_state(MyStates::Play)), timeout))
         .add_systems(OnEnter(MyStates::Load), use_splash_assets)
         .add_systems(OnEnter(MyStates::Play), use_loading_assets)

--- a/bevy_asset_loader/tests/multiple_states.rs
+++ b/bevy_asset_loader/tests/multiple_states.rs
@@ -3,7 +3,7 @@
 use bevy::app::AppExit;
 use bevy::audio::AudioPlugin;
 use bevy::prelude::*;
-use bevy_asset_loader::prelude::{AssetCollection, LoadingState, LoadingStateAppExt};
+use bevy_asset_loader::prelude::*;
 
 #[cfg(all(
     not(feature = "2d"),
@@ -20,10 +20,16 @@ fn main() {
         ))
         .add_state::<Loading>()
         .add_state::<Game>()
-        .add_loading_state(LoadingState::new(Game::Booting).continue_to_state(Game::Loading))
-        .add_collection_to_loading_state::<_, GameStateCollection>(Game::Booting)
-        .add_loading_state(LoadingState::new(Loading::Loading).continue_to_state(Loading::Finalize))
-        .add_collection_to_loading_state::<_, LoadingStateCollection>(Loading::Loading)
+        .add_loading_state(
+            LoadingState::new(Game::Booting)
+                .continue_to_state(Game::Loading)
+                .load_collection::<GameStateCollection>(),
+        )
+        .add_loading_state(
+            LoadingState::new(Loading::Loading)
+                .continue_to_state(Loading::Finalize)
+                .load_collection::<LoadingStateCollection>(),
+        )
         .add_systems(Update, (quit.run_if(in_state(Game::Play)), timeout))
         .add_systems(
             OnEnter(Game::Loading),

--- a/bevy_asset_loader/tests/reload_dynamic_asset_files.rs
+++ b/bevy_asset_loader/tests/reload_dynamic_asset_files.rs
@@ -22,21 +22,21 @@ fn main() {
         ))
         .insert_resource(SplashTimer(Timer::from_seconds(1.0, TimerMode::Once)))
         .add_loading_state(
-            LoadingState::new(MyStates::SplashAssetLoading).continue_to_state(MyStates::Splash),
-        )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
-            MyStates::SplashAssetLoading,
-            "full_dynamic_collection.assets.ron",
+            LoadingState::new(MyStates::SplashAssetLoading)
+                .continue_to_state(MyStates::Splash)
+                .with_dynamic_assets_file::<StandardDynamicAssetCollection>(
+                    "full_dynamic_collection.assets.ron",
+                ),
         )
         .add_systems(Update, splash_countdown.run_if(in_state(MyStates::Splash)))
         .add_loading_state(
-            LoadingState::new(MyStates::MainMenuAssetLoading).continue_to_state(MyStates::MainMenu),
+            LoadingState::new(MyStates::MainMenuAssetLoading)
+                .continue_to_state(MyStates::MainMenu)
+                .with_dynamic_assets_file::<StandardDynamicAssetCollection>(
+                    "full_dynamic_collection.assets.ron",
+                )
+                .load_collection::<MainMenuAssets>(),
         )
-        .add_dynamic_collection_to_loading_state::<_, StandardDynamicAssetCollection>(
-            MyStates::MainMenuAssetLoading,
-            "full_dynamic_collection.assets.ron",
-        )
-        .add_collection_to_loading_state::<_, MainMenuAssets>(MyStates::MainMenuAssetLoading)
         .add_systems(Update, (timeout, quit.run_if(in_state(MyStates::MainMenu))))
         .run();
 }

--- a/bevy_asset_loader_derive/Cargo.toml
+++ b/bevy_asset_loader_derive/Cargo.toml
@@ -19,6 +19,9 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2 = "1.0"
 syn = "2.0"

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -86,7 +86,7 @@ fn impl_asset_collection(
                         for error in errors {
                             match error {
                                 ParseFieldError::NoAttributes => {
-                                    from_world_fields.push(field.clone().ident.unwrap())
+                                    from_world_fields.push(field.clone().ident.unwrap());
                                 }
                                 ParseFieldError::KeyAttributeStandsAlone => {
                                     compile_errors.push(syn::Error::new_spanned(
@@ -418,7 +418,7 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                 } else {
                                     errors.push(ParseFieldError::UnknownAttribute(
                                         meta_path.into_token_stream(),
-                                    ))
+                                    ));
                                 }
                             }
                             _ => {

--- a/ideas.md
+++ b/ideas.md
@@ -1,7 +1,0 @@
-API could be split roughly following the add_systems/configure_sets APIs from Bevy
-
-e.g.
-
-app.configure_loading_state(MySate::Loading, add_collection::<MyCollection>().init_resource::<SomeResource>())
-
-This cuts down on boilerplate and is more "Bevy like"


### PR DESCRIPTION
```rust
        .add_collection_to_loading_state::<_, ImageAssets>(MyStates::AssetLoading)
        .init_resource_after_loading_state::<_, CombinedImage>(MyStates::AssetLoading)
```
becomes
```rust
        .configure_loading_state(
            LoadingStateConfig::new(MyStates::AssetLoading)
                .load_collection::<ImageAssets>()
                .init_resource::<CombinedImage>(),
        )
```

Also resolves #164 with an improved error when configuring a loading state that is not added to the application yet.