### PR TITLE
Support ron format maps as assets

### DIFF
--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -15,6 +15,8 @@ pub enum DynamicAssetType {
     Single(UntypedHandle),
     /// Dynamic asset that is defined by multiple handles
     Collection(Vec<UntypedHandle>),
+    /// Dynamic asset that is a map of multiple handles
+    Map(HashMap<String, DynamicAssetType>),
 }
 
 /// Any type implementing this trait can be assigned to asset keys as part of a dynamic

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -465,6 +465,27 @@ impl AssetField {
                 }
                 folder_map
             },
+            ::bevy_asset_loader::prelude::DynamicAssetType::Map(data) => {
+                let asset_server = world.get_resource::<::bevy::asset::AssetServer>().expect("Cannot get AssetServer");
+                let mut asset_map = ::bevy::utils::HashMap::default();
+                for (key, handle) in data {
+                    // match handle {
+                    //     ::bevy_asset_loader::prelude::DynamicAssetType::Single(handle) => {
+                    //         asset_map.insert(key, #handle);
+                    //     }
+                    //     ::bevy_asset_loader::prelude::DynamicAssetType::Collection(handles) => {
+                    //         asset_map.insert(key, #handles);
+                    //     }
+                    //     ::bevy_asset_loader::prelude::DynamicAssetType::Map(handle) => {
+                    //         asset_map.insret(key, #handle);
+                    //     }
+                    // }
+                    if let ::bevy_asset_loader::prelude::DynamicAssetType::Single(handle) = handle {
+                        asset_map.insert(key, #handle);
+                    }
+                }
+                asset_map
+            },
             result => panic!("The dynamic asset '{}' cannot be created. The asset collection {} expected it to resolve to `Collection(handle)`, but {asset:?} resolves to {result:?}", #asset_key, #name),
         )
     }


### PR DESCRIPTION
This is a Frankenstein way to force functionality with maps in ron to work with this library. This is due to #179.

Given what I needed this to be able to do it does that with only a minor modification required on the user side.
That change is wrapping the `{}` in `()` first, but this may be able to be worked around as well.

Feel free to touch up or change anything within this, its very far from being published or merged as it is just a proof of concept for now.