### PR TITLE
Add Support for Dynamic Asset Collections

### DIFF
--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -87,7 +87,8 @@ pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "standard_dynamic_assets")]
     pub use crate::standard_dynamic_asset::{
-        RegisterStandardDynamicAsset, StandardDynamicAsset, StandardDynamicAssetCollection,
+        RegisterStandardDynamicAsset, StandardDynamicAsset, StandardDynamicAssetArrayCollection,
+        StandardDynamicAssetCollection,
     };
     #[doc(hidden)]
     pub use crate::{


### PR DESCRIPTION
This PR introduces the ability to load and build collections of dynamic assets in bevy_asset_loader, addressing the need outlined in issue [#186](https://github.com/NiklasEi/bevy_asset_loader/issues/186). The enhancement allows for more flexible asset management, enabling users to define and group dynamic assets in structured collections.

## Motivation
Previously, loading multiple dynamic assets required individual handling for each asset, complicating the asset loading process and cluttering the codebase. With this update, users can now group related assets together, simplifying the loading process (specially for applications that handles a huge number of assets dynamically).

## Changes
DynamicAsset Trait for Vec<StandardDynamicAsset>: Implemented the DynamicAsset trait for Vec<StandardDynamicAsset>, enabling the loading and building of asset collections.

StandardDynamicAssetArrayCollection: Introduced a new struct to represent collections of dynamic assets, allowing assets to be grouped and registered under a common key.

## Usage Example
With these changes, users can now define array of asset collections in RON format:
```ron
({
    "layouts": [
        TextureAtlasLayout (
            tile_size_x: 32.,
            tile_size_y: 32.,
            columns: 12,
            rows: 12,
        ),
        TextureAtlasLayout (
            tile_size_x: 32.,
            tile_size_y: 64.,
            columns: 12,
            rows: 6,
        ),
        TextureAtlasLayout (
            tile_size_x: 64.,
            tile_size_y: 32.,
            columns: 6,
            rows: 12,
        ),
        TextureAtlasLayout (
            tile_size_x: 64.,
            tile_size_y: 64.,
            columns: 6,
            rows: 6,
        ),
    ],
    "mixed": [
        StandardMaterial (
            path: "images/tree.png",
        ),
        Image (
            path: "ryot_mascot.png",
            sampler: Nearest
        ),
        Image (
            path: "ryot_mascot.png",
            sampler: Nearest
        ),
    ],
})
```
 
And the rust code would look like:
```rust
    #[asset(key = "layouts", collection(typed))]
    atlas_layout: Vec<Handle<TextureAtlasLayout>>,

    #[asset(key = "mixed", collection)]
    mixed_handlers: Vec<UntypedHandle>,
```

## Conclusion
This update offers a straightforward method for managing multiple dynamic assets within the bevy_asset_loader. It's particularly beneficial for applications dealing with a large number of assets dynamically, aiming to simplify the process and improve developer experience. By grouping assets into collections, it hopes to make dynamic asset handling more accessible and less cumbersome.





