### PR TITLE
Fix derive macro with texture atlas layouts

### DIFF
--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -516,7 +516,7 @@ pub(crate) enum InternalLoadingState<S: States> {
     LoadingDynamicAssetCollections,
     /// Load the actual asset collections and check their status every frame.
     LoadingAssets,
-    /// All collections are loaded and inserted. Time to e.g. run custom [insert_resource](bevy_asset_loader::AssetLoader::insert_resource).
+    /// All collections are loaded and inserted. Time to e.g. run custom [`insert_resource`](bevy_asset_loader::AssetLoader::insert_resource).
     Finalize,
     /// A 'parking' state in case no next state is defined
     Done(PhantomData<S>),

--- a/bevy_asset_loader/tests/ui/no_default.stderr
+++ b/bevy_asset_loader/tests/ui/no_default.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `NoDefault: std::default::Default` is not satisfied
+error[E0277]: the trait bound `NoDefault: FromWorld` is not satisfied
  --> tests/ui/no_default.rs:8:5
   |
 8 |     no_default: NoDefault,

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -465,7 +465,7 @@ impl AssetField {
                 )
             }
             AssetField::TextureAtlasLayout(TextureAtlasLayoutAssetField { .. }) => {
-                quote!()
+                quote!(#token_stream)
             }
             AssetField::StandardMaterial(BasicAssetField { asset_path, .. })
             | AssetField::Image(ImageAssetField { asset_path, .. }) => {


### PR DESCRIPTION
Without this, any fields prior to a texture atlas layout field are omitted from the `AssetCollection::load` function