### PR TITLE
Support for additional ImageSamplerDescriptor properties (Fixes #215)

### DIFF
--- a/bevy_asset_loader/src/standard_dynamic_asset.rs
+++ b/bevy_asset_loader/src/standard_dynamic_asset.rs
@@ -16,6 +16,7 @@ use bevy::sprite::TextureAtlasLayout;
 
 #[cfg(any(feature = "3d", feature = "2d"))]
 use bevy::render::texture::{Image, ImageSampler, ImageSamplerDescriptor};
+use bevy::render::texture::{ImageAddressMode, ImageCompareFunction, ImageFilterMode, ImageSamplerBorderColor};
 
 /// These asset variants can be loaded from configuration files. They will then replace
 /// a dynamic asset based on their keys.
@@ -49,6 +50,39 @@ pub enum StandardDynamicAsset {
         /// Sampler
         #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
         sampler: Option<ImageSamplerType>,
+        /// ImageAddressMode
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    address_mode_u: Option<ImageAddressModeType>,
+        /// ImageAddressMode
+	    #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    address_mode_v: Option<ImageAddressModeType>,
+        /// ImageAddressMode
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    address_mode_w: Option<ImageAddressModeType>,
+        /// ImageFilterMode
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    mag_filter: Option<ImageFilterModeType>,
+        /// ImageFilterMode
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    min_filter: Option<ImageFilterModeType>,
+        /// ImageFilterMode
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    mipmap_filter: Option<ImageFilterModeType>,
+        /// f32
+	    #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    lod_min_clamp: Option<f32>,
+        /// f32
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    lod_max_clamp: Option<f32>,
+        /// ImageCompareFunction
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    compare: Option<ImageCompareFunctionType>,
+        /// u16
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    anisotropy_clamp: Option<u16>,
+        /// ImageSamplerBorderColor
+        #[serde(with = "optional", skip_serializing_if = "Option::is_none", default)]
+	    border_color: Option<ImageSamplerBorderColorType>,
     },
     /// A dynamic standard material asset directly loaded from an image file
     #[cfg(feature = "3d")]
@@ -137,6 +171,122 @@ impl From<ImageSamplerType> for ImageSampler {
     }
 }
 
+/// Defines the ImageAddressMode
+#[allow(dead_code)]
+#[cfg(any(feature = "3d", feature = "2d"))]
+#[derive(Debug, PartialEq, Clone, Copy, Default, Deserialize, Serialize)]
+pub enum ImageAddressModeType {
+    #[default]
+    /// See [`ImageAddressMode::ClampToEdge`]
+    ClampToEdge,
+    /// See [`ImageAddressMode::Repeat`]
+    Repeat,
+    /// See [`ImageAddressMode::MirrorRepeat`]
+    MirrorRepeat,
+    /// See [`ImageAddressMode::ClampToBorder`]
+    ClampToBorder,
+}
+
+#[cfg(any(feature = "3d", feature = "2d"))]
+impl Into<ImageAddressMode> for ImageAddressModeType {
+    fn into(self) -> ImageAddressMode {
+        match self {
+            ImageAddressModeType::ClampToEdge => ImageAddressMode::ClampToEdge,
+            ImageAddressModeType::Repeat => ImageAddressMode::Repeat,
+            ImageAddressModeType::MirrorRepeat => ImageAddressMode::MirrorRepeat,
+            ImageAddressModeType::ClampToBorder => ImageAddressMode::ClampToBorder,
+        }
+    }
+}
+
+/// Defines the ImageFilterMode
+#[allow(dead_code)]
+#[cfg(any(feature = "3d", feature = "2d"))]
+#[derive(Debug, PartialEq, Clone, Copy, Default, Deserialize, Serialize)]
+pub enum ImageFilterModeType {
+    #[default]
+    /// See [`ImageFilterMode::Nearest`]
+    Nearest,
+    /// See [`ImageFilterMode::Linear`]
+    Linear,
+}
+
+#[cfg(any(feature = "3d", feature = "2d"))]
+impl Into<ImageFilterMode> for ImageFilterModeType {
+    fn into(self) -> ImageFilterMode {
+        match self {
+            ImageFilterModeType::Nearest => ImageFilterMode::Nearest,
+            ImageFilterModeType::Linear => ImageFilterMode::Linear,
+        }
+    }
+}
+
+/// Defines the ImageCompareFunction
+#[allow(dead_code)]
+#[cfg(any(feature = "3d", feature = "2d"))]
+#[derive(Debug, PartialEq, Clone, Copy, Deserialize, Serialize)]
+pub enum ImageCompareFunctionType {
+    /// See [`ImageCompareFunction::Never`]
+    Never,
+    /// See [`ImageCompareFunction::Less`]
+    Less,
+    /// See [`ImageCompareFunction::Equal`]
+    Equal,
+    /// See [`ImageCompareFunction::LessEqual`]
+    LessEqual,
+    /// See [`ImageCompareFunction::Greater`]
+    Greater,
+    /// See [`ImageCompareFunction::NotEqual`]
+    NotEqual,
+    /// See [`ImageCompareFunction::GreaterEqual`]
+    GreaterEqual,
+    /// See [`ImageCompareFunction::Always`]
+    Always,
+}
+
+#[cfg(any(feature = "3d", feature = "2d"))]
+impl Into<ImageCompareFunction> for ImageCompareFunctionType {
+    fn into(self) -> ImageCompareFunction {
+        match self {
+            ImageCompareFunctionType::Never => ImageCompareFunction::Never,
+            ImageCompareFunctionType::Less => ImageCompareFunction::Less,
+            ImageCompareFunctionType::Equal => ImageCompareFunction::Equal,
+            ImageCompareFunctionType::LessEqual => ImageCompareFunction::LessEqual,
+            ImageCompareFunctionType::Greater => ImageCompareFunction::Greater,
+            ImageCompareFunctionType::NotEqual => ImageCompareFunction::NotEqual,
+            ImageCompareFunctionType::GreaterEqual => ImageCompareFunction::GreaterEqual,
+            ImageCompareFunctionType::Always => ImageCompareFunction::Always,
+        }
+    }
+}
+
+/// Defines the ImageSamplerBorderColor
+#[allow(dead_code)]
+#[cfg(any(feature = "3d", feature = "2d"))]
+#[derive(Debug, PartialEq, Clone, Copy, Deserialize, Serialize)]
+pub enum ImageSamplerBorderColorType {
+    /// See [`ImageSamplerBorderColor::TransparentBlack`]
+    TransparentBlack,
+    /// See [`ImageSamplerBorderColor::OpaqueBlack`]
+    OpaqueBlack,
+    /// See [`ImageSamplerBorderColor::OpaqueWhite`]
+    OpaqueWhite,
+    /// See [`ImageSamplerBorderColor::Zero`]
+    Zero,
+}
+
+#[cfg(any(feature = "3d", feature = "2d"))]
+impl Into<ImageSamplerBorderColor> for ImageSamplerBorderColorType {
+    fn into(self) -> ImageSamplerBorderColor {
+        match self {
+            ImageSamplerBorderColorType::TransparentBlack => ImageSamplerBorderColor::TransparentBlack,
+            ImageSamplerBorderColorType::OpaqueBlack => ImageSamplerBorderColor::OpaqueBlack,
+            ImageSamplerBorderColorType::OpaqueWhite => ImageSamplerBorderColor::OpaqueWhite,
+            ImageSamplerBorderColorType::Zero => ImageSamplerBorderColor::Zero,
+        }
+    }
+}
+
 impl DynamicAsset for StandardDynamicAsset {
     fn load(&self, asset_server: &AssetServer) -> Vec<UntypedHandle> {
         match self {
@@ -171,13 +321,53 @@ impl DynamicAsset for StandardDynamicAsset {
                 asset_server.get_handle_untyped(path).unwrap(),
             )),
             #[cfg(any(feature = "3d", feature = "2d"))]
-            StandardDynamicAsset::Image { path, sampler } => {
+            StandardDynamicAsset::Image {
+                path,
+                sampler,
+                address_mode_u,
+                address_mode_v,
+                address_mode_w,
+                mag_filter,
+                min_filter,
+                mipmap_filter,
+                lod_min_clamp,
+                lod_max_clamp,
+                compare,
+                anisotropy_clamp,
+                border_color,
+            } => {
                 let mut handle = asset_server.load(path);
-                if let Some(sampler) = sampler {
+                if sampler.is_some()
+                    || address_mode_u.is_some()
+                    || address_mode_v.is_some()
+                    || address_mode_w.is_some()
+                    || mag_filter.is_some()
+                    || min_filter.is_some()
+                    || mipmap_filter.is_some()
+                    || lod_min_clamp.is_some()
+                    || lod_max_clamp.is_some()
+                    || compare.is_some()
+                    || anisotropy_clamp.is_some()
+                    || border_color.is_some()
+                {
                     let mut images = cell
                         .get_resource_mut::<Assets<Image>>()
                         .expect("Cannot get resource Assets<Image>");
-                    Self::update_image_sampler(&mut handle, &mut images, sampler);
+                    Self::update_image_sampler(
+                        &mut handle, &mut images,
+                        sampler,
+                        address_mode_u,
+                        address_mode_v,
+                        address_mode_w,
+                        mag_filter,
+                        min_filter,
+                        mipmap_filter,
+                        lod_min_clamp,
+                        lod_max_clamp,
+                        compare,
+                        anisotropy_clamp,
+                        border_color,
+                    );
                 }
 
                 Ok(DynamicAssetType::Single(handle.untyped()))
@@ -252,22 +442,61 @@ impl StandardDynamicAsset {
     fn update_image_sampler(
         handle: &mut bevy::asset::Handle<Image>,
         images: &mut Assets<Image>,
-        sampler_type: &ImageSamplerType,
+        sampler_type: &Option<ImageSamplerType>,
+        address_mode_u: &Option<ImageAddressModeType>,
+        address_mode_v: &Option<ImageAddressModeType>,
+        address_mode_w: &Option<ImageAddressModeType>,
+        mag_filter: &Option<ImageFilterModeType>,
+        min_filter: &Option<ImageFilterModeType>,
+        mipmap_filter: &Option<ImageFilterModeType>,
+        lod_min_clamp: &Option<f32>,
+        lod_max_clamp: &Option<f32>,
+        compare: &Option<ImageCompareFunctionType>,
+        anisotropy_clamp: &Option<u16>,
+        border_color: &Option<ImageSamplerBorderColorType>,
     ) {
         let image = images.get_mut(&*handle).unwrap();
-        let is_different_sampler = if let ImageSampler::Descriptor(descriptor) = &image.sampler {
-            let configured_descriptor: ImageSamplerDescriptor = sampler_type.clone().into();
-            !descriptor.as_wgpu().eq(&configured_descriptor.as_wgpu())
+        
+        let mut descriptor = ImageSamplerDescriptor::default();
+        descriptor.address_mode_u = address_mode_u.unwrap_or_default().into();
+        descriptor.address_mode_v = address_mode_v.unwrap_or_default().into();
+        descriptor.address_mode_w = address_mode_w.unwrap_or_default().into();
+        if let Some(sampler) = sampler_type {
+            match sampler {
+                ImageSamplerType::Linear => {
+                    descriptor.mag_filter = ImageFilterModeType::Linear.into();
+                    descriptor.min_filter = ImageFilterModeType::Linear.into();
+                    descriptor.mipmap_filter = ImageFilterModeType::Linear.into();
+                }
+                ImageSamplerType::Nearest => {
+                    descriptor.mag_filter = ImageFilterModeType::Nearest.into();
+                    descriptor.min_filter = ImageFilterModeType::Nearest.into();
+                    descriptor.mipmap_filter = ImageFilterModeType::Nearest.into();
+                }
+            }
+        } else {
+            descriptor.mag_filter = mag_filter.unwrap_or_default().into();
+            descriptor.min_filter = min_filter.unwrap_or_default().into();
+            descriptor.mipmap_filter = mipmap_filter.unwrap_or_default().into();
+        }
+        descriptor.lod_min_clamp = lod_min_clamp.unwrap_or_default().into();
+        descriptor.lod_max_clamp = lod_max_clamp.unwrap_or_default().into();
+        descriptor.compare = if let Some(compare) = compare { Some(compare.clone().into()) } else { None };
+        descriptor.anisotropy_clamp = anisotropy_clamp.unwrap_or_default().into();
+        descriptor.border_color = if let Some(border_color) = border_color { Some(border_color.clone().into()) } else { None };
+        
+        let is_different_sampler = if let ImageSampler::Descriptor(original_descriptor) = &image.sampler {
+            !original_descriptor.as_wgpu().eq(&descriptor.as_wgpu())
         } else {
             false
         };
-
+        
         if is_different_sampler {
             let mut cloned_image = image.clone();
-            cloned_image.sampler = sampler_type.clone().into();
+            cloned_image.sampler = ImageSampler::Descriptor(descriptor);
             *handle = images.add(cloned_image);
         } else {
-            image.sampler = sampler_type.clone().into();
+            image.sampler = ImageSampler::Descriptor(descriptor);
         }
     }
 }
@@ -423,6 +652,8 @@ mod tests {
     "image": Image(
         path: "images/player.png",
         sampler: Linear,
+        address_mode_u: Repeat,
+        compare: Less,
     ),
 })"#;
         serialize_and_deserialize(dynamic_asset_file);

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -1,4 +1,3 @@
-use proc_macro::TokenStream;
 use crate::{ParseFieldError, TextureAtlasAttribute};
 use proc_macro2::{Ident, Spacing, Span, TokenStream, Punct};
 use quote::{quote, ToTokens, TokenStreamExt};
@@ -270,38 +269,6 @@ fn expand_to_tokens<T : ToTokens>(input: &Option<T>) -> TokenStream {
     }
 }
 
-fn image_to_settings (image: &ImageAssetField) -> TokenStream {
-    let image_address_mode_u = image.address_mode_u;
-    let image_address_mode_v = image.address_mode_v;
-    let image_address_mode_w = image.address_mode_w;
-    let image_mag_filter = image.mag_filter;
-    let image_min_filter = image.min_filter;
-    let image_mipmap_filter = image.mipmap_filter;
-    let image_lod_min_clamp = image.lod_min_clamp;
-    let image_lod_max_clamp = image.lod_max_clamp;
-    let image_compare = expand_to_tokens(&image.compare);
-    let image_anisotropy_clamp = image.anisotropy_clamp;
-    let image_border_color = expand_to_tokens(&image.border_color);
-    
-    quote!(
-        move |s: &mut ImageLoaderSettings| {
-            let mut descriptor = ImageSamplerDescriptor::default();
-            descriptor.address_mode_u = #image_address_mode_u;
-            descriptor.address_mode_v = #image_address_mode_v;
-            descriptor.address_mode_w = #image_address_mode_w;
-            descriptor.mag_filter = #image_mag_filter;
-            descriptor.min_filter = #image_min_filter;
-            descriptor.mipmap_filter = #image_mipmap_filter;
-            descriptor.lod_min_clamp = #image_lod_min_clamp;
-            descriptor.lod_max_clamp = #image_lod_max_clamp;
-            descriptor.compare = #image_compare;
-            descriptor.anisotropy_clamp = #image_anisotropy_clamp;
-            descriptor.border_color = #image_border_color;
-            s.sampler = ImageSampler::Descriptor(descriptor);
-        }
-    )
-}
-
 impl AssetField {
     pub(crate) fn attach_token_stream_for_creation(
         &self,
@@ -321,17 +288,58 @@ impl AssetField {
                 let field_ident = image.field_ident.clone();
                 let asset_path = image.asset_path.clone();
                 
-                let settings = image_to_settings(image);
+                let image_address_mode_u = image.address_mode_u;
+                let image_address_mode_v = image.address_mode_v;
+                let image_address_mode_w = image.address_mode_w;
+                let image_mag_filter = image.mag_filter;
+                let image_min_filter = image.min_filter;
+                let image_mipmap_filter = image.mipmap_filter;
+                let image_lod_min_clamp = image.lod_min_clamp;
+                let image_lod_max_clamp = image.lod_max_clamp;
+                let image_compare = expand_to_tokens(&image.compare);
+                let image_anisotropy_clamp = image.anisotropy_clamp;
+                let image_border_color = expand_to_tokens(&image.border_color);
                 
                 quote!(#token_stream #field_ident : {
                     use bevy::render::texture::{
                         ImageSampler, ImageSamplerDescriptor, ImageLoaderSettings, ImageAddressMode,
-                        ImageFilterMode, ImageCompareFunction, ImageSamplerBorderColor,
+                        ImageFilterMode, ImageCompareFunction, ImageSamplerBorderColor, Image,
                     };
                     let cell = world.cell();
                     let asset_server = cell.get_resource::<::bevy::asset::AssetServer>().expect("Cannot get AssetServer");
+                    let mut images = cell.get_resource_mut::<::bevy::asset::Assets<Image>>().expect("Cannot get resource Assets<Image>");
+                    
+                    let mut handle = asset_server.load(#asset_path);
+                    let mut image = images.get_mut(&handle).expect("Only asset collection fields holding an `Image` handle can be annotated with `image`");
                 
-                    asset_server.load_with_settings(#asset_path, #settings)
+                    let mut descriptor = ImageSamplerDescriptor::default();
+                    descriptor.address_mode_u = #image_address_mode_u;
+                    descriptor.address_mode_v = #image_address_mode_v;
+                    descriptor.address_mode_w = #image_address_mode_w;
+                    descriptor.mag_filter = #image_mag_filter;
+                    descriptor.min_filter = #image_min_filter;
+                    descriptor.mipmap_filter = #image_mipmap_filter;
+                    descriptor.lod_min_clamp = #image_lod_min_clamp;
+                    descriptor.lod_max_clamp = #image_lod_max_clamp;
+                    descriptor.compare = #image_compare;
+                    descriptor.anisotropy_clamp = #image_anisotropy_clamp;
+                    descriptor.border_color = #image_border_color;
+                    
+                    let is_different_sampler = if let ImageSampler::Descriptor(original_descriptor) = &image.sampler {
+                        !original_descriptor.as_wgpu().eq(&descriptor.as_wgpu())
+                    } else {
+                        false
+                    };
+
+                    if is_different_sampler {
+                        let mut cloned_image = image.clone();
+                        cloned_image.sampler = ImageSampler::Descriptor(descriptor);
+                        handle = images.add(cloned_image);
+                    } else {
+                        image.sampler = ImageSampler::Descriptor(descriptor);
+                    }
+
+                    handle
                 },)
             }
             AssetField::Folder(basic, typed, mapped) => {
@@ -644,21 +652,9 @@ impl AssetField {
             AssetField::TextureAtlasLayout(TextureAtlasLayoutAssetField { .. }) => {
                 quote!(#token_stream)
             }
-            AssetField::StandardMaterial(BasicAssetField { asset_path, .. }) => {
+            AssetField::StandardMaterial(BasicAssetField { asset_path, .. })
+            | AssetField::Image(ImageAssetField { asset_path, .. }) => {
                 quote!(#token_stream handles.push(asset_server.load::<::bevy::render::texture::Image>(#asset_path).untyped());)
-            }
-            AssetField::Image(image) => {
-                let asset_path = image.asset_path.clone();
-                let settings = image_to_settings(image);
-                
-                quote!(
-                    #token_stream
-                    use bevy::render::texture::{
-                        ImageSampler, ImageSamplerDescriptor, ImageLoaderSettings, ImageAddressMode,
-                        ImageFilterMode, ImageCompareFunction, ImageSamplerBorderColor,
-                    };
-                    handles.push(asset_server.load_with_settings::<::bevy::render::texture::Image, _>(#asset_path, #settings).untyped());
-                )
             }
             AssetField::Files(assets, _, _) => {
                 let asset_paths = assets.asset_paths.clone();

--- a/bevy_asset_loader_derive/src/assets.rs
+++ b/bevy_asset_loader_derive/src/assets.rs
@@ -1,6 +1,6 @@
 use crate::{ParseFieldError, TextureAtlasAttribute};
-use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use proc_macro2::{Ident, Spacing, Span, TokenStream, Punct};
+use quote::{quote, ToTokens, TokenStreamExt};
 
 #[derive(PartialEq, Debug)]
 pub(crate) struct TextureAtlasLayoutAssetField {
@@ -32,11 +32,170 @@ impl TryFrom<String> for SamplerType {
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub(crate) enum ImageAddressModeType {
+    #[default]
+    ClampToEdge,
+    Repeat,
+    MirrorRepeat,
+    ClampToBorder,
+}
+
+impl TryFrom<String> for ImageAddressModeType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "clamptoedge" => Ok(Self::ClampToEdge),
+            "repeat" => Ok(Self::Repeat),
+            "mirrorrepeat" => Ok(Self::MirrorRepeat),
+            "clamptoborder" => Ok(Self::ClampToBorder),
+            _ => Err("Value must be valid ImageAddressMode"),
+        }
+    }
+}
+
+impl ToTokens for ImageAddressModeType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Ident::new("ImageAddressMode", Span::call_site()));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        match *self {
+            ImageAddressModeType::ClampToEdge => tokens.append(Ident::new("ClampToEdge", Span::call_site())),
+            ImageAddressModeType::Repeat => tokens.append(Ident::new("Repeat", Span::call_site())),
+            ImageAddressModeType::MirrorRepeat => tokens.append(Ident::new("MirrorRepeat", Span::call_site())),
+            ImageAddressModeType::ClampToBorder => tokens.append(Ident::new("ClampToBorder", Span::call_site())),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
+pub(crate) enum ImageFilterModeType {
+    #[default]
+    Nearest,
+    Linear,
+}
+
+impl TryFrom<String> for ImageFilterModeType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "linear" => Ok(Self::Linear),
+            "nearest" => Ok(Self::Nearest),
+            _ => Err("Value must be valid ImageFilterMode"),
+        }
+    }
+}
+
+impl ToTokens for ImageFilterModeType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Ident::new("ImageFilterMode", Span::call_site()));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        match *self {
+            ImageFilterModeType::Linear => tokens.append(Ident::new("Linear", Span::call_site())),
+            ImageFilterModeType::Nearest => tokens.append(Ident::new("Nearest", Span::call_site())),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) enum ImageCompareFunctionType {
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always,
+}
+
+impl TryFrom<String> for ImageCompareFunctionType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "never" => Ok(Self::Never),
+            "less" => Ok(Self::Less),
+            "equal" => Ok(Self::Equal),
+            "lessequal" => Ok(Self::LessEqual),
+            "greater" => Ok(Self::Greater),
+            "notequal" => Ok(Self::NotEqual),
+            "greaterequal" => Ok(Self::GreaterEqual),
+            "always" => Ok(Self::Always),
+            _ => Err("Value must be valid ImageCompareFunction"),
+        }
+    }
+}
+
+impl ToTokens for ImageCompareFunctionType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Ident::new("ImageCompareFunction", Span::call_site()));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        match *self {
+            ImageCompareFunctionType::Never => tokens.append(Ident::new("Never", Span::call_site())),
+            ImageCompareFunctionType::Less => tokens.append(Ident::new("Less", Span::call_site())),
+            ImageCompareFunctionType::Equal => tokens.append(Ident::new("Equal", Span::call_site())),
+            ImageCompareFunctionType::LessEqual => tokens.append(Ident::new("LessEqual", Span::call_site())),
+            ImageCompareFunctionType::Greater => tokens.append(Ident::new("Greater", Span::call_site())),
+            ImageCompareFunctionType::NotEqual => tokens.append(Ident::new("NotEqual", Span::call_site())),
+            ImageCompareFunctionType::GreaterEqual => tokens.append(Ident::new("GreaterEqual", Span::call_site())),
+            ImageCompareFunctionType::Always => tokens.append(Ident::new("Always", Span::call_site())),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub(crate) enum ImageSamplerBorderColorType {
+    TransparentBlack,
+    OpaqueBlack,
+    OpaqueWhite,
+    Zero,
+}
+
+impl TryFrom<String> for ImageSamplerBorderColorType {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "transparentblack" => Ok(Self::TransparentBlack),
+            "opaqueblack" => Ok(Self::OpaqueBlack),
+            "opaquewhite" => Ok(Self::OpaqueWhite),
+            "zero" => Ok(Self::Zero),
+            _ => Err("Value must be valid ImageSamplerBorderColor")
+        }
+    }
+}
+
+impl ToTokens for ImageSamplerBorderColorType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append(Ident::new("ImageSamplerBorderColor", Span::call_site()));
+        tokens.append(Punct::new(':', Spacing::Joint));
+        tokens.append(Punct::new(':', Spacing::Alone));
+        match *self {
+            ImageSamplerBorderColorType::TransparentBlack => tokens.append(Ident::new("TransparentBlack", Span::call_site())),
+            ImageSamplerBorderColorType::OpaqueBlack => tokens.append(Ident::new("OpaqueBlack", Span::call_site())),
+            ImageSamplerBorderColorType::OpaqueWhite => tokens.append(Ident::new("OpaqueWhite", Span::call_site())),
+            ImageSamplerBorderColorType::Zero => tokens.append(Ident::new("Zero", Span::call_site())),
+        }
+    }
+}
+
 #[derive(PartialEq, Debug)]
 pub(crate) struct ImageAssetField {
     pub field_ident: Ident,
     pub asset_path: String,
     pub sampler: SamplerType,
+    pub address_mode_u: ImageAddressModeType,
+    pub address_mode_v: ImageAddressModeType,
+    pub address_mode_w: ImageAddressModeType,
+    pub mag_filter: ImageFilterModeType,
+    pub min_filter: ImageFilterModeType,
+    pub mipmap_filter: ImageFilterModeType,
+    pub lod_min_clamp: f32,
+    pub lod_max_clamp: f32,
+    pub compare: Option<ImageCompareFunctionType>,
+    pub anisotropy_clamp: u16,
+    pub border_color: Option<ImageSamplerBorderColorType>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -122,39 +281,51 @@ impl AssetField {
             AssetField::Image(image) => {
                 let field_ident = image.field_ident.clone();
                 let asset_path = image.asset_path.clone();
-                let sampler = match image.sampler {
-                    SamplerType::Linear => quote!(ImageSampler::linear()),
-                    SamplerType::Nearest => quote!(ImageSampler::nearest()),
-                };
+                
                 let descriptor = match image.sampler {
                     SamplerType::Linear => quote!(ImageSamplerDescriptor::linear()),
                     SamplerType::Nearest => quote!(ImageSamplerDescriptor::nearest()),
                 };
+                
+                let image_address_mode_u = image.address_mode_u;
+                let image_address_mode_v = image.address_mode_v;
+                let image_address_mode_w = image.address_mode_w;
+                let image_mag_filter = image.mag_filter;
+                let image_min_filter = image.min_filter;
+                let image_mipmap_filter = image.mipmap_filter;
+                let image_lod_min_clamp = image.lod_min_clamp;
+                let image_lod_max_clamp = image.lod_max_clamp;
+                let image_compare = image.compare;
+                let image_anisotropy_clamp = image.anisotropy_clamp;
+                let image_border_color = image.border_color;
+                
+                let settings = quote!(
+                   move |s: &mut ImageLoaderSettings| {
+                        let mut descriptor = #descriptor;
+                        descriptor.address_mode_u = #image_address_mode_u;
+                        descriptor.address_mode_v = #image_address_mode_v;
+                        descriptor.address_mode_w = #image_address_mode_w;
+                        descriptor.mag_filter = #image_mag_filter;
+                        descriptor.min_filter = #image_min_filter;
+                        descriptor.mipmap_filter = #image_mipmap_filter;
+                        descriptor.lod_min_clamp = #image_lod_min_clamp;
+                        descriptor.lod_max_clamp = #image_lod_max_clamp;
+                        descriptor.compare = #image_compare;
+                        descriptor.anisotropy_clamp = #image_anisotropy_clamp;
+                        descriptor.border_color = #image_border_color;
+                        s.sampler = ImageSampler::Descriptor(descriptor);
+                    };
+                );
 
                 quote!(#token_stream #field_ident : {
-                    use bevy::render::texture::{ImageSampler, ImageSamplerDescriptor};
+                    use bevy::render::texture::{
+                        ImageSampler, ImageSamplerDescriptor, ImageLoaderSettings, ImageAddressMode,
+                        ImageFilterMode, ImageCompareFunction, ImageSamplerBorderColor,
+                    };
                     let cell = world.cell();
                     let asset_server = cell.get_resource::<AssetServer>().expect("Cannot get AssetServer");
-                    let mut images = cell.get_resource_mut::<Assets<Image>>().expect("Cannot get resource Assets<Image>");
 
-                    let mut handle = asset_server.load(#asset_path);
-                    let mut image = images.get_mut(&handle).expect("Only asset collection fields holding an `Image` handle can be annotated with `image`");
-
-                    let is_different_sampler = if let ImageSampler::Descriptor(descriptor) = &image.sampler {
-                        !descriptor.as_wgpu().eq(&#descriptor.as_wgpu())
-                    } else {
-                        false
-                    };
-
-                    if is_different_sampler {
-                        let mut cloned_image = image.clone();
-                        cloned_image.sampler = #sampler;
-                        handle = images.add(cloned_image);
-                    } else {
-                        image.sampler = #sampler;
-                    }
-
-                    handle
+                    asset_server.load_with_settings(#asset_path, #settings)
                 },)
             }
             AssetField::Folder(basic, typed, mapped) => {
@@ -491,6 +662,7 @@ pub(crate) struct AssetBuilder {
     pub is_typed: bool,
     pub is_mapped: bool,
     pub key: Option<String>,
+    
     pub tile_size_x: Option<f32>,
     pub tile_size_y: Option<f32>,
     pub columns: Option<usize>,
@@ -499,7 +671,19 @@ pub(crate) struct AssetBuilder {
     pub padding_y: Option<f32>,
     pub offset_x: Option<f32>,
     pub offset_y: Option<f32>,
+    
     pub sampler: Option<SamplerType>,
+    pub address_mode_u: Option<ImageAddressModeType>,
+    pub address_mode_v: Option<ImageAddressModeType>,
+    pub address_mode_w: Option<ImageAddressModeType>,
+    pub mag_filter: Option<ImageFilterModeType>,
+    pub min_filter: Option<ImageFilterModeType>,
+    pub mipmap_filter: Option<ImageFilterModeType>,
+    pub lod_min_clamp: Option<f32>,
+    pub lod_max_clamp: Option<f32>,
+    pub compare: Option<Option<ImageCompareFunctionType>>,
+    pub anisotropy_clamp: Option<u16>,
+    pub border_color: Option<Option<ImageSamplerBorderColorType>>,
 }
 
 impl AssetBuilder {
@@ -629,6 +813,17 @@ impl AssetBuilder {
                 field_ident: self.field_ident.unwrap(),
                 asset_path: self.asset_path.unwrap(),
                 sampler: self.sampler.unwrap(),
+                address_mode_u: self.address_mode_u.unwrap_or_default(),
+                address_mode_v: self.address_mode_v.unwrap_or_default(),
+                address_mode_w: self.address_mode_w.unwrap_or_default(),
+                mag_filter: self.mag_filter.unwrap_or_default(),
+                min_filter: self.min_filter.unwrap_or_default(),
+                mipmap_filter: self.mipmap_filter.unwrap_or_default(),
+                lod_min_clamp: self.lod_min_clamp.unwrap_or(0.),
+                lod_max_clamp: self.lod_max_clamp.unwrap_or(32.),
+                compare: self.compare.unwrap_or_default(),
+                anisotropy_clamp: self.anisotropy_clamp.unwrap_or(1),
+                border_color: self.border_color.unwrap_or_default(),
             }));
         }
         let asset = BasicAssetField {
@@ -910,7 +1105,18 @@ mod test {
             AssetField::Image(ImageAssetField {
                 field_ident: Ident::new("test", Span::call_site()),
                 asset_path: "some/image.png".to_owned(),
-                sampler: SamplerType::Linear
+                sampler: SamplerType::Linear,
+                address_mode_u: Default::default(),
+                address_mode_v: Default::default(),
+                address_mode_w: Default::default(),
+                mag_filter: Default::default(),
+                min_filter: Default::default(),
+                mipmap_filter: Default::default(),
+                lod_min_clamp: 0.0,
+                lod_max_clamp: 32.0,
+                compare: None,
+                anisotropy_clamp: 1,
+                border_color: None,
             })
         );
         assert_eq!(
@@ -918,7 +1124,18 @@ mod test {
             AssetField::Image(ImageAssetField {
                 field_ident: Ident::new("test", Span::call_site()),
                 asset_path: "some/image.png".to_owned(),
-                sampler: SamplerType::Nearest
+                sampler: SamplerType::Nearest,
+                address_mode_u: Default::default(),
+                address_mode_v: Default::default(),
+                address_mode_w: Default::default(),
+                mag_filter: Default::default(),
+                min_filter: Default::default(),
+                mipmap_filter: Default::default(),
+                lod_min_clamp: 0.0,
+                lod_max_clamp: 32.0,
+                compare: None,
+                anisotropy_clamp: 1,
+                border_color: None,
             })
         );
     }

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -483,18 +483,35 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                 Meta::NameValue(named_value) => {
                                     let path = named_value.path.get_ident().unwrap().clone();
                                     if path == ImageAttribute::SAMPLER {
-                                        if let Expr::Path(ExprPath { path, .. }) =
-                                            &named_value.value
-                                        {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
                                             let sampler_result = SamplerType::try_from(
                                                 path.get_ident().unwrap().to_string(),
                                             );
-
+                                            
                                             if let Ok(sampler) = sampler_result {
                                                 builder.sampler = Some(sampler);
                                             } else {
                                                 errors.push(ParseFieldError::UnknownAttribute(
                                                     named_value.value.into_token_stream(),
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::ADDRESS_MODE_U {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageAddressModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(address_mode_u) = result {
+                                                builder.address_mode_u = Some(address_mode_u);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
                                                 ));
                                             }
                                         } else {
@@ -536,9 +553,8 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                                 ));
                                             }
                                         } else {
-                                            errors.push(ParseFieldError::WrongAttributeType(
-                                                named_value.into_token_stream(),
-                                                "path",
+                                            errors.push(ParseFieldError::UnknownAttribute(
+                                                named_value.value.into_token_stream()
                                             ));
                                         }
                                     } else if path == ImageAttribute::MAG_FILTER {
@@ -623,7 +639,7 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                             );
                                             
                                             if let Ok(compare) = result {
-                                                builder.compare = Some(Some(compare));
+                                                builder.compare = Some(compare);
                                             } else {
                                                 errors.push(ParseFieldError::UnknownAttribute(
                                                     named_value.value.into_token_stream()
@@ -651,7 +667,7 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                             );
                                             
                                             if let Ok(border_color) = result {
-                                                builder.border_color = Some(Some(border_color));
+                                                builder.border_color = Some(border_color);
                                             } else {
                                                 errors.push(ParseFieldError::UnknownAttribute(
                                                     named_value.value.into_token_stream()

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -62,6 +62,30 @@ impl ImageAttribute {
     pub const ATTRIBUTE_NAME: &'static str = "image";
     #[allow(dead_code)]
     pub const SAMPLER: &'static str = "sampler";
+    #[allow(dead_code)]
+    pub const ADDRESS_MODE_U: &'static str = "address_mode_u";
+    #[allow(dead_code)]
+    pub const ADDRESS_MODE_V: &'static str = "address_mode_v";
+    #[allow(dead_code)]
+    pub const ADDRESS_MODE_W: &'static str = "address_mode_w";
+    #[allow(dead_code)]
+    pub const MAG_FILTER: &'static str = "mag_filter";
+    #[allow(dead_code)]
+    pub const MIN_FILTER: &'static str = "min_filter";
+    #[allow(dead_code)]
+    pub const MIPMAP_FILTER: &'static str = "mipmap_filter";
+    #[allow(dead_code)]
+    pub const LOD_MIN_CLAMP: &'static str = "lod_min_clamp";
+    #[allow(dead_code)]
+    pub const LOD_MAX_CLAMP: &'static str = "lod_max_clamp";
+    #[allow(dead_code)]
+    pub const COMPARE: &'static str = "compare";
+    #[allow(dead_code)]
+    pub const ANISOTROPY_CLAMP: &'static str = "anisotropy_clamp";
+    #[allow(dead_code)]
+    pub const BORDER_COLOR: &'static str = "border_color";
+    #[allow(dead_code)]
+    pub const LABEL: &'static str = "label";
 }
 
 pub(crate) const COLLECTION_ATTRIBUTE: &str = "collection";
@@ -471,6 +495,166 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                             } else {
                                                 errors.push(ParseFieldError::UnknownAttribute(
                                                     named_value.value.into_token_stream(),
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::ADDRESS_MODE_V {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageAddressModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(address_mode_v) = result {
+                                                builder.address_mode_v = Some(address_mode_v);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::ADDRESS_MODE_W {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageAddressModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(address_mode_w) = result {
+                                                builder.address_mode_w = Some(address_mode_w);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::MAG_FILTER {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageFilterModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(mag_filter) = result {
+                                                builder.mag_filter = Some(mag_filter);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::MIN_FILTER {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageFilterModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(min_filter) = result {
+                                                builder.min_filter = Some(min_filter);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::MIPMAP_FILTER {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageFilterModeType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(mipmap_filter) = result {
+                                                builder.mipmap_filter = Some(mipmap_filter);
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::LOD_MIN_CLAMP {
+                                        if let Expr::Lit(ExprLit { lit: Lit::Float(lod_min_clamp), .. }) = &named_value.value {
+                                            builder.lod_min_clamp = Some(lod_min_clamp.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float"
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::LOD_MAX_CLAMP {
+                                        if let Expr::Lit(ExprLit { lit: Lit::Float(lod_max_clamp), .. }) = &named_value.value {
+                                            builder.lod_max_clamp = Some(lod_max_clamp.base10_parse::<f32>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "float"
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::COMPARE {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageCompareFunctionType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(compare) = result {
+                                                builder.compare = Some(Some(compare));
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
+                                                ));
+                                            }
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "path",
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::ANISOTROPY_CLAMP {
+                                        if let Expr::Lit(ExprLit { lit: Lit::Int(anisotropy_clamp), .. }) = &named_value.value {
+                                            builder.anisotropy_clamp = Some(anisotropy_clamp.base10_parse::<u16>().unwrap());
+                                        } else {
+                                            errors.push(ParseFieldError::WrongAttributeType(
+                                                named_value.into_token_stream(),
+                                                "integer"
+                                            ));
+                                        }
+                                    } else if path == ImageAttribute::BORDER_COLOR {
+                                        if let Expr::Path(ExprPath { path, .. }) = &named_value.value {
+                                            let result = ImageSamplerBorderColorType::try_from(
+                                                path.get_ident().unwrap().to_string()
+                                            );
+                                            
+                                            if let Ok(border_color) = result {
+                                                builder.border_color = Some(Some(border_color));
+                                            } else {
+                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                    named_value.value.into_token_stream()
                                                 ));
                                             }
                                         } else {


### PR DESCRIPTION
I'm not a Rust expert so there's probably a cleaner ways of doing things! 

There's quite a lot of boilerplate to get internal Bevy enums working with the derive parameters and I think that could be tidied up with macros, but I figured I'd wait to see the feedback on this before working on it.