### PR TITLE
Add support for repeating texture wrap modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,16 @@ use bevy_asset_loader::asset_collection::AssetCollection;
 #[derive(AssetCollection, Resource)]
 struct ImageAssets {
     #[asset(path = "images/pixel_tree.png")]
-    #[asset(image(sampler = linear))]
+    #[asset(image(sampler(filter = linear)))]
     tree_linear: Handle<Image>,
 
     #[asset(path = "images/pixel_tree.png")]
-    #[asset(image(sampler = nearest))]
+    #[asset(image(sampler(filter = nearest)))]
     tree_nearest: Handle<Image>,
+
+    #[asset(path = "images/pixel_tree.png")]
+    #[asset(image(sampler(filter = linear, repeat)))]
+    tree_linear_repeat: Handle<Image>,
 }
 ```
 
@@ -260,11 +264,18 @@ The corresponding dynamic asset would be
 ({
     "tree_nearest": Image (
         path: "images/tree.png",
-        sampler: Nearest
+        filter: Nearest,
+        wrap: Clamp
     ),
     "tree_linear": Image (
         path: "images/tree.png",
-        sampler: Linear
+        filter: Linear,
+        wrap: Clamp
+    ),
+    "tree_linear_repeat": Image (
+        path: "images/tree.png",
+        filter: Linear,
+        wrap: Repeat
     ),
 })
 ```

--- a/bevy_asset_loader/examples/atlas_from_grid.rs
+++ b/bevy_asset_loader/examples/atlas_from_grid.rs
@@ -29,7 +29,7 @@ struct MyAssets {
     #[asset(texture_atlas_layout(tile_size_x = 96, tile_size_y = 99, columns = 8, rows = 1))]
     female_adventurer_layout: Handle<TextureAtlasLayout>,
     // you can configure the sampler for the sprite sheet image
-    #[asset(image(sampler = nearest))]
+    #[asset(image(sampler(filter = nearest)))]
     #[asset(path = "images/female_adventurer_sheet.png")]
     female_adventurer: Handle<Image>,
 }

--- a/bevy_asset_loader/examples/image_asset.rs
+++ b/bevy_asset_loader/examples/image_asset.rs
@@ -18,11 +18,11 @@ fn main() {
 #[derive(AssetCollection, Resource)]
 struct ImageAssets {
     #[asset(path = "images/pixel_tree.png")]
-    #[asset(image(sampler = linear))]
+    #[asset(image(sampler(filter = linear)))]
     tree_linear: Handle<Image>,
 
     #[asset(path = "images/pixel_tree.png")]
-    #[asset(image(sampler = nearest))]
+    #[asset(image(sampler(filter = nearest)))]
     tree_nearest: Handle<Image>,
 
     #[asset(path = "images/array_texture.png")]

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -66,6 +66,17 @@ impl ImageAttribute {
     pub const LAYERS: &'static str = "array_texture_layers";
 }
 
+#[allow(dead_code)]
+pub(crate) struct SamplerAttribute;
+impl SamplerAttribute {
+    #[allow(dead_code)]
+    pub const FILTER: &'static str = "filter";
+    #[allow(dead_code)]
+    pub const CLAMP: &'static str = "clamp";
+    #[allow(dead_code)]
+    pub const REPEAT: &'static str = "repeat";
+}
+
 pub(crate) const COLLECTION_ATTRIBUTE: &str = "collection";
 pub(crate) const PATHS_ATTRIBUTE: &str = "paths";
 pub(crate) const TYPED_ATTRIBUTE: &str = "typed";
@@ -455,30 +466,82 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                             .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated);
                         for attribute in image_meta_list.unwrap() {
                             match attribute {
+                                Meta::List(meta_list) => {
+                                    let path = meta_list.path.get_ident().unwrap().clone();
+                                    if path == ImageAttribute::SAMPLER {
+                                        let sampler_meta_list = meta_list
+                                            .parse_args_with(
+                                                Punctuated::<Meta, Token![,]>::parse_terminated,
+                                            )
+                                            .unwrap();
+                                        for attribute in &sampler_meta_list {
+                                            match attribute {
+                                                Meta::NameValue(named_value) => {
+                                                    let path = named_value
+                                                        .path
+                                                        .get_ident()
+                                                        .unwrap()
+                                                        .clone();
+                                                    if path == SamplerAttribute::FILTER {
+                                                        if let Expr::Path(ExprPath {
+                                                            path, ..
+                                                        }) = &named_value.value
+                                                        {
+                                                            let filter_result =
+                                                                FilterType::try_from(
+                                                                    path.get_ident()
+                                                                        .unwrap()
+                                                                        .to_string(),
+                                                                );
+
+                                                            if let Ok(filter) = filter_result {
+                                                                builder.filter = Some(filter);
+                                                            } else {
+                                                                errors.push(ParseFieldError::UnknownAttribute(
+                                                                    named_value.value.clone().into_token_stream(),
+                                                                ));
+                                                            }
+                                                        } else {
+                                                            errors.push(
+                                                                ParseFieldError::WrongAttributeType(
+                                                                    named_value.into_token_stream(),
+                                                                    "path",
+                                                                ),
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                                Meta::Path(path) => {
+                                                    let path = path.get_ident().unwrap().clone();
+                                                    if path == SamplerAttribute::CLAMP {
+                                                        builder.wrap = Some(WrapMode::Clamp);
+                                                    } else if path == SamplerAttribute::REPEAT {
+                                                        builder.wrap = Some(WrapMode::Repeat);
+                                                    } else {
+                                                        errors.push(
+                                                            ParseFieldError::UnknownAttribute(
+                                                                path.into_token_stream(),
+                                                            ),
+                                                        );
+                                                    }
+                                                }
+                                                Meta::List(_) => {
+                                                    errors.push(
+                                                        ParseFieldError::WrongAttributeType(
+                                                            sampler_meta_list
+                                                                .clone()
+                                                                .into_token_stream(),
+                                                            "name-value or path",
+                                                        ),
+                                                    );
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                                 Meta::NameValue(named_value) => {
                                     let path = named_value.path.get_ident().unwrap().clone();
-                                    if path == ImageAttribute::SAMPLER {
-                                        if let Expr::Path(ExprPath { path, .. }) =
-                                            &named_value.value
-                                        {
-                                            let sampler_result = SamplerType::try_from(
-                                                path.get_ident().unwrap().to_string(),
-                                            );
-
-                                            if let Ok(sampler) = sampler_result {
-                                                builder.sampler = Some(sampler);
-                                            } else {
-                                                errors.push(ParseFieldError::UnknownAttribute(
-                                                    named_value.value.into_token_stream(),
-                                                ));
-                                            }
-                                        } else {
-                                            errors.push(ParseFieldError::WrongAttributeType(
-                                                named_value.into_token_stream(),
-                                                "path",
-                                            ));
-                                        }
-                                    } else if path == ImageAttribute::LAYERS {
+                                    if path == ImageAttribute::LAYERS {
                                         if let Expr::Lit(ExprLit {
                                             lit: Lit::Int(layers),
                                             ..
@@ -492,6 +555,10 @@ fn parse_field(field: &Field) -> Result<AssetField, Vec<ParseFieldError>> {
                                                 "u32",
                                             ));
                                         }
+                                    } else {
+                                        errors.push(ParseFieldError::UnknownAttributeType(
+                                            path.into_token_stream(),
+                                        ));
                                     }
                                 }
                                 _ => {


### PR DESCRIPTION
This is a less ambitious version of #216 that should be ready to go. It changes `#[image(sampler = linear)]` and `#[image(sampler = nearest)]` to `#[image(sampler(filter = linear))]` and `#[image(sampler(filter = nearest))]` respectively. The `sampler` list also supports `repeat` and `clamp` modes. So, for example, you can write `#[image(sampler(filter = linear, repeat)]` or `#[image(sampler(repeat))]`.

Closes #235.