### PR TITLE
Make SubStates work

### DIFF
--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -121,3 +121,7 @@ required-features = ["2d"]
 [[example]]
 name = "asset_maps"
 path = "examples/asset_maps.rs"
+
+[[example]]
+name = "sub_state"
+path = "examples/sub_state.rs"

--- a/bevy_asset_loader/examples/README.md
+++ b/bevy_asset_loader/examples/README.md
@@ -3,23 +3,24 @@
 These examples are simple Bevy Apps illustrating the capabilities of `bevy_asset_loader`. Run the examples
 with `cargo run --example <example>`.
 
-| Example                                                  | Description                                                              |
-|----------------------------------------------------------|--------------------------------------------------------------------------|
-| [`atlas_from_grid.rs`](atlas_from_grid.rs)               | Loading a texture atlas from a sprite sheet                              |
-| [`custom_dynamic_assets.rs`](custom_dynamic_assets.rs)   | Define and use your own dynamic assets                                   |
-| [`dynamic_asset.rs`](dynamic_asset.rs)                   | Load dynamic assets from a `.ron` file                                   |
-| [`failure_state.rs`](failure_state.rs)                   | Sets up a failure state                                                  |
-| [`full_collection.rs`](full_collection.rs)               | A complete asset collection with all supported non-dynamic field types   |
+| Example                                                    | Description                                                              |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [`atlas_from_grid.rs`](atlas_from_grid.rs)                 | Loading a texture atlas from a sprite sheet                              |
+| [`custom_dynamic_assets.rs`](custom_dynamic_assets.rs)     | Define and use your own dynamic assets                                   |
+| [`dynamic_asset.rs`](dynamic_asset.rs)                     | Load dynamic assets from a `.ron` file                                   |
+| [`failure_state.rs`](failure_state.rs)                     | Sets up a failure state                                                  |
+| [`full_collection.rs`](full_collection.rs)                 | A complete asset collection with all supported non-dynamic field types   |
 | [`full_dynamic_collection.rs`](full_dynamic_collection.rs) | A complete asset collection with all supported dynamic asset field types |
-| [`image_asset.rs`](image_asset.rs)                       | How to set different samplers for image assets                           |
-| [`init_resource.rs`](init_resource.rs)                   | Inserting a `FromWorld` resource when all asset collections are loaded   |
-| [`manual_dynamic_asset.rs`](manual_dynamic_asset.rs)     | Load an image asset from a path resolved at run time                     |
-| [`no_loading_state.rs`](no_loading_state.rs)             | How to use asset collections without a loading state                     |
-| [`progress_tracking.rs`](progress_tracking.rs)           | How to set up progress tracking using `iyes_progress`                    |
-| [`standard_material.rs`](standard_material.rs)           | Loading a standard material from a png file                              |
-| [`two_collections.rs`](two_collections.rs)               | Load multiple asset collections                                          |
-| [`asset_maps.rs`](asset_maps.rs)                         | Shows how to use different types as keys in asset maps                   |
-| [`dynamic_asset_arrays.rs`](dynamic_asset_arrays.rs)                         | Defines dynamic assets in arrays                                         |
+| [`image_asset.rs`](image_asset.rs)                         | How to set different samplers for image assets                           |
+| [`init_resource.rs`](init_resource.rs)                     | Inserting a `FromWorld` resource when all asset collections are loaded   |
+| [`manual_dynamic_asset.rs`](manual_dynamic_asset.rs)       | Load an image asset from a path resolved at run time                     |
+| [`no_loading_state.rs`](no_loading_state.rs)               | How to use asset collections without a loading state                     |
+| [`progress_tracking.rs`](progress_tracking.rs)             | How to set up progress tracking using `iyes_progress`                    |
+| [`standard_material.rs`](standard_material.rs)             | Loading a standard material from a png file                              |
+| [`sub_state.rs`](sub_state.rs)                             | How to use a sub state                                                   |
+| [`two_collections.rs`](two_collections.rs)                 | Load multiple asset collections                                          |
+| [`asset_maps.rs`](asset_maps.rs)                           | Shows how to use different types as keys in asset maps                   |
+| [`dynamic_asset_arrays.rs`](dynamic_asset_arrays.rs)       | Defines dynamic assets in arrays                                         |
 
 ## Credits
 

--- a/bevy_asset_loader/examples/sub_state.rs
+++ b/bevy_asset_loader/examples/sub_state.rs
@@ -1,0 +1,83 @@
+use bevy::app::AppExit;
+use bevy::input::common_conditions::input_just_pressed;
+use bevy::prelude::*;
+use bevy_asset_loader::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+
+    app.add_plugins(DefaultPlugins);
+
+    app.init_state::<AppState>();
+    app.add_sub_state::<MainMenuState>();
+
+    app.add_loading_state(
+        LoadingState::new(MainMenuState::Loading)
+            .continue_to_state(MainMenuState::Active)
+            .on_failure_continue_to_state(MainMenuState::Error)
+            .load_collection::<MyAssets>(),
+    );
+
+    app.add_systems(OnEnter(AppState::Booting), booting)
+        .add_systems(
+            Update,
+            finish_booting
+                .run_if(in_state(AppState::Booting).and_then(input_just_pressed(KeyCode::Space))),
+        );
+
+    app.add_systems(Update, timeout.run_if(in_state(MainMenuState::Loading)))
+        .add_systems(OnEnter(MainMenuState::Active), fail)
+        .add_systems(OnEnter(MainMenuState::Error), ok);
+
+    app.run();
+}
+
+#[derive(AssetCollection, Resource)]
+struct MyAssets {
+    #[asset(path = "audio/plop.ogg")]
+    _plop: Handle<AudioSource>,
+    #[asset(path = "non-existing-file.ogg")]
+    _non_existing_file: Handle<AudioSource>,
+    #[asset(path = "audio/background.ogg")]
+    _background: Handle<AudioSource>,
+}
+
+fn fail() {
+    panic!("The library should have switched to the failure state!");
+}
+
+fn ok(mut quit: EventWriter<AppExit>) {
+    info!("As expected, bevy_asset_loader switched to the failure state");
+    info!("Quitting the application...");
+    quit.send(AppExit::Success);
+}
+
+fn booting() {
+    info!("Booting...press space to finish booting");
+}
+
+fn finish_booting(mut state: ResMut<NextState<AppState>>) {
+    state.set(AppState::MainMenu);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.elapsed_seconds_f64() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(Clone, Copy, Default, Eq, PartialEq, Debug, Hash, States)]
+pub enum AppState {
+    #[default]
+    Booting,
+    MainMenu,
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, SubStates)]
+#[source(AppState = AppState::MainMenu)]
+pub enum MainMenuState {
+    #[default]
+    Loading,
+    Error,
+    Active,
+}

--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -205,15 +205,15 @@ pub(crate) fn run_loading_state<S: FreelyMutableState>(world: &mut World) {
 }
 
 pub fn apply_internal_state_transition<S: FreelyMutableState>(world: &mut World) {
-    let state = world.resource::<State<S>>().get().clone();
     let next_state = world.remove_resource::<NextState<InternalLoadingState<S>>>();
     match next_state {
         Some(NextState::Pending(entered_state)) => {
             let exited_state = world.remove_resource::<State<InternalLoadingState<S>>>();
             world.insert_resource(State::new(entered_state.clone()));
             trace!(
-            "Switching internal state of loading state from {exited_state:?} to {entered_state:?}"
-        );
+                "Switching internal state of loading state from {exited_state:?} to {entered_state:?}"
+            );
+            let state = world.resource::<State<S>>().get().clone();
             if world
                 .resource::<Schedules>()
                 .contains(OnEnterInternalLoadingState(

--- a/bevy_asset_loader/tests/can_run_with_sub_states.rs
+++ b/bevy_asset_loader/tests/can_run_with_sub_states.rs
@@ -1,0 +1,101 @@
+use bevy::app::AppExit;
+use bevy::asset::AssetPlugin;
+use bevy::audio::AudioPlugin;
+use bevy::prelude::*;
+use bevy::state::app::StatesPlugin;
+use bevy_asset_loader::prelude::*;
+
+#[test]
+fn can_run_with_sub_states() {
+    let mut app = App::new();
+
+    app.add_plugins((
+        MinimalPlugins,
+        AssetPlugin::default(),
+        AudioPlugin::default(),
+        StatesPlugin,
+    ));
+    app.init_state::<MyStates>();
+    app.add_sub_state::<MainMenuState>();
+    #[cfg(feature = "progress_tracking")]
+    app.add_plugins(iyes_progress::ProgressPlugin::new(MainMenuState::Loading));
+    app.add_loading_state(LoadingState::new(MainMenuState::Loading).load_collection::<MyAssets>())
+        .init_resource::<TestState>()
+        .add_systems(
+            Update,
+            (
+                load_main_menu.run_if(in_state(MyStates::Load)),
+                expect.run_if(in_state(MainMenuState::Loading)),
+                timeout.run_if(in_state(MainMenuState::Loading)),
+            ),
+        )
+        .run();
+}
+
+fn load_main_menu(mut state: ResMut<NextState<MyStates>>) {
+    state.set(MyStates::MainMenu);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.elapsed_seconds_f64() > 30. {
+        panic!("The asset loader did not load the collection in 30 seconds");
+    }
+}
+
+fn expect(
+    collection: Option<Res<MyAssets>>,
+    mut exit: EventWriter<AppExit>,
+    mut test_state: ResMut<TestState>,
+) {
+    if collection.is_some() {
+        if test_state.wait_frames_after_load == 0 {
+            exit.send(AppExit::Success);
+            return;
+        }
+        test_state.wait_frames_after_load -= 1;
+    }
+}
+
+#[derive(Resource)]
+struct TestState {
+    wait_frames_after_load: usize,
+}
+
+impl Default for TestState {
+    fn default() -> Self {
+        TestState {
+            wait_frames_after_load: 5,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(AssetCollection, Resource)]
+struct MyAssets {
+    #[asset(path = "audio/background.ogg")]
+    background: Handle<AudioSource>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Default, States)]
+enum MyStates {
+    #[default]
+    Load,
+    MainMenu,
+}
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, SubStates)]
+#[source(MyStates = MyStates::MainMenu)]
+enum MainMenuState {
+    #[default]
+    Loading,
+    #[expect(
+        dead_code,
+        reason = "not used in test, but useful to show how to use it"
+    )]
+    Error,
+    #[expect(
+        dead_code,
+        reason = "not used in test, but useful to show how to use it"
+    )]
+    Active,
+}

--- a/bevy_asset_loader_derive/src/lib.rs
+++ b/bevy_asset_loader_derive/src/lib.rs
@@ -170,7 +170,7 @@ fn impl_asset_collection(
         }
     } else {
         return Err(vec![syn::Error::new_spanned(
-            &ast.into_token_stream(),
+            ast.into_token_stream(),
             "AssetCollection can only be derived for a struct",
         )]);
     }


### PR DESCRIPTION
Prior to this change, Bevy `SubStates` do not work. Running the new example gives this panic:

```
❯ cargo run --example sub_state
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/examples/sub_state`
2024-10-21T11:30:32.578903Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "MacOS 14.4.1 ", kernel: "23.4.0", cpu: "Apple M1 Max", core_count: "10", memory: "64.0 GiB" }
2024-10-21T11:30:32.681630Z  INFO bevy_render::renderer: AdapterInfo { name: "Apple M1 Max", vendor: 0, device: 0, device_type: IntegratedGpu, driver: "", driver_info: "", backend: Metal }
2024-10-21T11:30:33.216368Z  INFO bevy_winit::system: Creating new window "App" (Entity { index: 0, generation: 1 })
thread 'main' panicked at /me/bevy_asset_loader/bevy_asset_loader/src/loading_state/systems.rs:208:23:
Requested resource bevy_state::state::resources::State<sub_state::MainMenuState> does not exist in the `World`.
                Did you forget to add it using `app.insert_resource` / `app.init_resource`?
                Resources are also implicitly added via `app.add_event`,
                and can be added by plugins.
stack backtrace:
...
```

With my fix, the new example works:

```
❯ cargo run --example sub_state
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/examples/sub_state`
2024-10-21T11:48:12.776700Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "MacOS 14.4.1 ", kernel: "23.4.0", cpu: "Apple M1 Max", core_count: "10", memory: "64.0 GiB" }
2024-10-21T11:48:12.871491Z  INFO bevy_render::renderer: AdapterInfo { name: "Apple M1 Max", vendor: 0, device: 0, device_type: IntegratedGpu, driver: "", driver_info: "", backend: Metal }
2024-10-21T11:48:13.397125Z  INFO bevy_winit::system: Creating new window "App" (Entity { index: 0, generation: 1 })
2024-10-21T11:48:13.430028Z  INFO sub_state: Booting...press space to finish booting
2024-10-21T11:48:14.211241Z ERROR bevy_asset::server: Path not found: /me/bevy_asset_loader/bevy_asset_loader/assets/non-existing-file.ogg
2024-10-21T11:48:14.227443Z  INFO sub_state: As expected, bevy_asset_loader switched to the failure state
2024-10-21T11:48:14.227467Z  INFO sub_state: Quitting the application...
```

I also added a test to prove it works.

The change seems sensible to me: We shouldn't look up the `State<S>` resource unless there is at least some next state, so it's just moved down. The reason this can't be at the top is that when you add a sub state in Bevy using `app.add_sub_state::<S>()`, Bevy doesn't seem to initialise the `State<S>` resource, not sure why.