### PR TITLE
Rename init_resource on a loading state to finally_init_resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- renamed `init_resource` to `finally_init_resource` to emphasise the difference to Bevy's `init_resource`
+
 ## v0.22.0 - 01.12.2024
 - support for Bevy 0.15
 - support for using sub states as loading states ([@mgi388](https://github.com/mgi388) in [#239](https://github.com/NiklasEi/bevy_asset_loader/pull/239))

--- a/README.md
+++ b/README.md
@@ -477,9 +477,9 @@ Any field in an asset collection without any attribute is required to implement 
 
 ## Initializing FromWorld resources
 
-In situations where you would like to prepare other resources based on your loaded asset collections you can use `LoadingState::init_resource` or `LoadingStateConfig::init_resource` to initialize `FromWorld` resources. See [init_resource.rs](/bevy_asset_loader/examples/init_resource.rs) for an example that loads two images and then combines their pixel data into a third image.
+In situations where you would like to prepare other resources based on your loaded asset collections you can use `LoadingState::finally_init_resource` or `LoadingStateConfig::finally_init_resource` to initialize `FromWorld` resources. See [finally_init_resource.rs](/bevy_asset_loader/examples/finally_init_resource.rs) for an example that loads two images and then combines their pixel data into a third image.
 
-Both `init_resource` methods from `bevy_asset_loader` do the same as Bevy's `App::init_resource`, but at a different point in time. While Bevy inserts your resources at application startup, `bevy_asset_loader` will initialize them only after your asset collections are available. That means you can use your asset collections in the `FromWorld` implementation of the resource.
+Both `finally_init_resource` methods from `bevy_asset_loader` do the same as Bevy's `App::init_resource`, but at a different point in time. While Bevy inserts your resources at application startup, `bevy_asset_loader` will initialize them only after your asset collections are available. That means you can use your asset collections in the `FromWorld` implementation of the resource.
 
 ## Progress tracking
 

--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -57,8 +57,8 @@ path = "examples/atlas_from_grid.rs"
 required-features = ["2d"]
 
 [[example]]
-name = "init_resource"
-path = "examples/init_resource.rs"
+name = "finally_init_resource"
+path = "examples/finally_init_resource.rs"
 
 [[example]]
 name = "manual_dynamic_asset"

--- a/bevy_asset_loader/examples/README.md
+++ b/bevy_asset_loader/examples/README.md
@@ -12,7 +12,7 @@ with `cargo run --example <example>`.
 | [`full_collection.rs`](full_collection.rs)                 | A complete asset collection with all supported non-dynamic field types   |
 | [`full_dynamic_collection.rs`](full_dynamic_collection.rs) | A complete asset collection with all supported dynamic asset field types |
 | [`image_asset.rs`](image_asset.rs)                         | How to set different samplers for image assets                           |
-| [`init_resource.rs`](init_resource.rs)                     | Inserting a `FromWorld` resource when all asset collections are loaded   |
+| [`finally_init_resource.rs`](finally_init_resource.rs)     | Inserting a `FromWorld` resource when all asset collections are loaded   |
 | [`manual_dynamic_asset.rs`](manual_dynamic_asset.rs)       | Load an image asset from a path resolved at run time                     |
 | [`no_loading_state.rs`](no_loading_state.rs)               | How to use asset collections without a loading state                     |
 | [`progress_tracking.rs`](progress_tracking.rs)             | How to set up progress tracking using `iyes_progress`                    |

--- a/bevy_asset_loader/examples/configure_loading_state.rs
+++ b/bevy_asset_loader/examples/configure_loading_state.rs
@@ -37,7 +37,7 @@ impl Plugin for PlayerAndMusicPlugin {
                 LoadingStateConfig::new(MyStates::AssetLoading)
                     .load_collection::<AudioAssets>()
                     .load_collection::<ImageAssets>()
-                    .init_resource::<ExampleResource>(),
+                    .finally_init_resource::<ExampleResource>(),
             );
     }
 }

--- a/bevy_asset_loader/examples/finally_init_resource.rs
+++ b/bevy_asset_loader/examples/finally_init_resource.rs
@@ -2,9 +2,9 @@ use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
 use bevy_asset_loader::prelude::*;
 
-/// This example demonstrates how you can use [`LoadingState::init_resource`] to initialize
+/// This example demonstrates how you can use [`LoadingState::finally_init_resource`] to initialize
 /// assets implementing [`FromWorld`] after your collections are inserted into the ECS.
-/// The same is possible with [`LoadingStateConfig::init_resource`] from anywhere in your Bevy application
+/// The same is possible with [`LoadingStateConfig::finally_init_resource`] from anywhere in your Bevy application
 ///
 /// In this showcase we load two images in an [`AssetCollection`] and then combine
 /// them by adding up their pixel data.
@@ -16,7 +16,7 @@ fn main() {
             LoadingState::new(MyStates::AssetLoading)
                 .continue_to_state(MyStates::Next)
                 .load_collection::<ImageAssets>()
-                .init_resource::<CombinedImage>(),
+                .finally_init_resource::<CombinedImage>(),
         )
         .add_systems(OnEnter(MyStates::Next), draw)
         .run();

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -477,6 +477,10 @@ impl<S: FreelyMutableState> ConfigureLoadingState for LoadingState<S> {
 
         self
     }
+
+    fn init_resource<R: Resource + FromWorld>(self) -> Self {
+        self.finally_init_resource::<R>()
+    }
 }
 
 ///  Systems in this set check the loading state of assets.

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -28,8 +28,8 @@ use dynamic_asset_systems::{
     resume_to_loading_asset_collections,
 };
 use systems::{
-    check_loading_collection, finish_loading_state, init_resource, initialize_loading_state,
-    reset_loading_state, resume_to_finalize, start_loading_collection,
+    check_loading_collection, finally_init_resource, finish_loading_state,
+    initialize_loading_state, reset_loading_state, resume_to_finalize, start_loading_collection,
 };
 
 #[cfg(feature = "standard_dynamic_assets")]
@@ -459,8 +459,8 @@ impl<S: FreelyMutableState> ConfigureLoadingState for LoadingState<S> {
         self
     }
 
-    fn init_resource<R: Resource + FromWorld>(mut self) -> Self {
-        self.config = self.config.init_resource::<R>();
+    fn finally_init_resource<R: Resource + FromWorld>(mut self) -> Self {
+        self.config = self.config.finally_init_resource::<R>();
 
         self
     }
@@ -717,7 +717,7 @@ pub trait LoadingStateAppExt {
     ///           LoadingState::new(GameState::Loading)
     ///             .continue_to_state(GameState::Menu)
     ///             .load_collection::<TextureForAtlas>()
-    ///             .init_resource::<TextureAtlasLayoutFromWorld>()
+    ///             .finally_init_resource::<TextureAtlasLayoutFromWorld>()
     ///         )
     /// #       .set_runner(|mut app| {app.update(); AppExit::Success})
     /// #       .run();
@@ -748,7 +748,7 @@ pub trait LoadingStateAppExt {
     /// ```
     #[deprecated(
         since = "0.19.0",
-        note = "Use `LoadingState::init_resource` or `LoadingStateConfig::init_resource` instead."
+        note = "Use `LoadingState::finally_init_resource` or `LoadingStateConfig::finally_init_resource` instead."
     )]
     fn init_resource_after_loading_state<S: FreelyMutableState, A: Resource + FromWorld>(
         &mut self,
@@ -833,7 +833,7 @@ impl LoadingStateAppExt for App {
     ) -> &mut Self {
         self.add_systems(
             OnEnterInternalLoadingState(loading_state, InternalLoadingState::Finalize),
-            init_resource::<A>,
+            finally_init_resource::<A>,
         )
     }
 }

--- a/bevy_asset_loader/src/loading_state/config.rs
+++ b/bevy_asset_loader/src/loading_state/config.rs
@@ -48,6 +48,17 @@ pub trait ConfigureLoadingState {
     /// See the `dynamic_asset` example
     #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
     fn with_dynamic_assets_file<C: DynamicAssetCollection + Asset>(self, file: &str) -> Self;
+
+    /// The resource will be initialized at the end of the loading state using its [`FromWorld`] implementation.
+    /// All asset collections will be available at that point and fully loaded.
+    ///
+    /// See the `finally_init_resource` example
+    #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
+    #[deprecated(
+        since = "0.22.1",
+        note = "Method has been renamed to `finally_init_resource`"
+    )]
+    fn init_resource<R: Resource + FromWorld>(self) -> Self;
 }
 
 /// Can be used to add new asset collections or similar configuration to a loading state.
@@ -191,5 +202,9 @@ impl<S: FreelyMutableState> ConfigureLoadingState for LoadingStateConfig<S> {
         self.with_dynamic_assets_type_id(file, TypeId::of::<C>());
 
         self
+    }
+
+    fn init_resource<R: Resource + FromWorld>(self) -> Self {
+        self.finally_init_resource::<R>()
     }
 }

--- a/bevy_asset_loader/src/loading_state/config.rs
+++ b/bevy_asset_loader/src/loading_state/config.rs
@@ -4,7 +4,7 @@ use crate::loading_state::dynamic_asset_systems::{
     check_dynamic_asset_collections, load_dynamic_asset_collections,
 };
 use crate::loading_state::systems::{
-    check_loading_collection, init_resource, start_loading_collection,
+    check_loading_collection, finally_init_resource, start_loading_collection,
 };
 use crate::loading_state::{
     InternalLoadingState, InternalLoadingStateSet, LoadingStateSchedule,
@@ -32,9 +32,9 @@ pub trait ConfigureLoadingState {
     /// The resource will be initialized at the end of the loading state using its [`FromWorld`] implementation.
     /// All asset collections will be available at that point and fully loaded.
     ///
-    /// See the `init_resource` example
+    /// See the `finally_init_resource` example
     #[must_use = "The configuration will only be applied when passed to App::configure_loading_state"]
-    fn init_resource<R: Resource + FromWorld>(self) -> Self;
+    fn finally_init_resource<R: Resource + FromWorld>(self) -> Self;
 
     /// Register a custom dynamic asset collection type
     ///
@@ -169,9 +169,9 @@ impl<S: FreelyMutableState> ConfigureLoadingState for LoadingStateConfig<S> {
         self
     }
 
-    fn init_resource<R: Resource + FromWorld>(mut self) -> Self {
+    fn finally_init_resource<R: Resource + FromWorld>(mut self) -> Self {
         self.on_enter_finalize
-            .push(init_resource::<R>.into_configs());
+            .push(finally_init_resource::<R>.into_configs());
 
         self
     }

--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -16,9 +16,8 @@ use iyes_progress::{ProgressEntryId, ProgressTracker};
 use std::any::{type_name, TypeId};
 use std::marker::PhantomData;
 
-pub(crate) fn init_resource<Asset: Resource + FromWorld>(world: &mut World) {
-    let asset = Asset::from_world(world);
-    world.insert_resource(asset);
+pub(crate) fn finally_init_resource<Asset: Resource + FromWorld>(world: &mut World) {
+    world.init_resource::<Asset>();
 }
 
 #[allow(clippy::type_complexity)]

--- a/bevy_asset_loader/tests/finally_init_resource.rs
+++ b/bevy_asset_loader/tests/finally_init_resource.rs
@@ -6,7 +6,7 @@ use bevy::state::app::StatesPlugin;
 use bevy_asset_loader::prelude::*;
 
 #[test]
-fn init_resource() {
+fn finally_init_resource() {
     let mut app = App::new();
 
     app.add_plugins((
@@ -20,7 +20,7 @@ fn init_resource() {
         LoadingState::new(MyStates::Load)
             .continue_to_state(MyStates::Next)
             .load_collection::<MyAssets>()
-            .init_resource::<PostProcessed>(),
+            .finally_init_resource::<PostProcessed>(),
     )
     .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
     .add_systems(OnEnter(MyStates::Next), expect)


### PR DESCRIPTION
Resolves #244

Also changes `finally_init_resource` to not overwrite existing resources of the same type. This follows Bevys behaviour of `init_resource`.