### PR TITLE
Depend on bevy subcrates directly v2

### DIFF
--- a/bevy_asset_loader/Cargo.toml
+++ b/bevy_asset_loader/Cargo.toml
@@ -15,25 +15,42 @@ readme = "README.md"
 
 [features]
 # This feature adds support for bevy's TextureAtlas assets
-2d = ["bevy/bevy_sprite", "bevy/png", "bevy_asset_loader_derive/2d"]
+2d = [
+    "dep:bevy_image",
+    "dep:bevy_math",
+    "dep:bevy_render",
+    "dep:bevy_sprite",
+    "bevy_asset_loader_derive/2d",
+]
 # This feature adds support for bevy's StandardMaterial assets
-3d = ["bevy/bevy_pbr", "bevy/png", "bevy_asset_loader_derive/3d"]
+3d = [
+    "dep:bevy_image",
+    "dep:bevy_pbr",
+    "dep:bevy_render",
+    "bevy_asset_loader_derive/3d",
+]
 standard_dynamic_assets = ["dep:bevy_common_assets", "dep:serde"]
 progress_tracking = ["dep:iyes_progress"]
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
-    "bevy_asset",
-    "bevy_state",
-    "bevy_log",
-] }
+bevy_app = { version = "0.16.0", default-features = false }
+bevy_asset = { version = "0.16.0", default-features = false }
+bevy_ecs = { version = "0.16.0", default-features = false }
+bevy_image = { version = "0.16.0", default-features = false, optional = true }
+bevy_log = { version = "0.16.0", default-features = false }
+bevy_math = { version = "0.16.0", default-features = false, optional = true }
+bevy_pbr = { version = "0.16.0", default-features = false, optional = true }
+bevy_platform = { version = "0.16.0", default-features = false }
+bevy_reflect = { version = "0.16.0", default-features = false }
+bevy_render = { version = "0.16.0", default-features = false, optional = true }
+bevy_sprite = { version = "0.16.0", default-features = false, optional = true }
+bevy_state = { version = "0.16.0", default-features = false }
+bevy_utils = { version = "0.16.0", default-features = false }
 bevy_asset_loader_derive = { version = "0.23.0", path = "../bevy_asset_loader_derive" }
 anyhow = "1"
 path-slash = "0.2"
 
-bevy_common_assets = { version = "0.13.0", features = [
-    "ron",
-], optional = true }
+bevy_common_assets = { version = "0.13.0", features = ["ron"], optional = true }
 serde = { version = "1", optional = true }
 iyes_progress = { version = "0.14.0", optional = true }
 

--- a/bevy_asset_loader/src/asset_collection.rs
+++ b/bevy_asset_loader/src/asset_collection.rs
@@ -1,8 +1,7 @@
 use crate::dynamic_asset::DynamicAssets;
-use bevy::app::App;
-use bevy::asset::UntypedHandle;
-use bevy::ecs::resource::Resource;
-use bevy::ecs::world::World;
+use bevy_app::App;
+use bevy_asset::UntypedHandle;
+use bevy_ecs::{resource::Resource, world::World};
 
 pub use bevy_asset_loader_derive::AssetCollection;
 

--- a/bevy_asset_loader/src/dynamic_asset.rs
+++ b/bevy_asset_loader/src/dynamic_asset.rs
@@ -1,11 +1,10 @@
 use std::any::TypeId;
 use std::fmt::Debug;
 
-use bevy::asset::{Asset, AssetServer, UntypedHandle};
-use bevy::ecs::resource::Resource;
-use bevy::ecs::world::World;
-use bevy::platform::collections::HashMap;
-use bevy::state::state::FreelyMutableState;
+use bevy_asset::{Asset, AssetServer, UntypedHandle};
+use bevy_ecs::{resource::Resource, world::World};
+use bevy_platform::collections::HashMap;
+use bevy_state::state::FreelyMutableState;
 use std::marker::PhantomData;
 
 /// Different typed that can generate the asset field value of a dynamic asset

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -4,19 +4,19 @@ mod systems;
 /// Configuration of loading states
 pub mod config;
 
-use bevy::app::{App, Plugin};
-use bevy::asset::{Asset, UntypedHandle};
-use bevy::ecs::{
+use bevy_app::{App, Plugin, Update};
+use bevy_asset::{Asset, UntypedHandle};
+use bevy_ecs::{
     resource::Resource,
-    schedule::{InternedScheduleLabel, ScheduleLabel, SystemSet},
+    schedule::{InternedScheduleLabel, IntoScheduleConfigs, ScheduleLabel, SystemSet},
     world::FromWorld,
 };
-use bevy::platform::collections::{HashMap, HashSet};
-use bevy::prelude::{
-    IntoScheduleConfigs, NextState, OnEnter, State, StateTransition, States, Update, in_state,
+use bevy_platform::collections::{HashMap, HashSet};
+use bevy_state::{
+    condition::in_state,
+    state::{FreelyMutableState, NextState, OnEnter, State, StateTransition, States},
 };
-use bevy::state::state::FreelyMutableState;
-use bevy::utils::default;
+use bevy_utils::default;
 use std::any::TypeId;
 use std::marker::PhantomData;
 

--- a/bevy_asset_loader/src/loading_state/config.rs
+++ b/bevy_asset_loader/src/loading_state/config.rs
@@ -10,12 +10,17 @@ use crate::loading_state::{
     InternalLoadingState, InternalLoadingStateSet, LoadingStateSchedule,
     OnEnterInternalLoadingState,
 };
-use bevy::app::App;
-use bevy::asset::Asset;
-use bevy::ecs::schedule::ScheduleConfigs;
-use bevy::platform::collections::HashMap;
-use bevy::prelude::{BevyError, FromWorld, IntoScheduleConfigs, Resource, default};
-use bevy::state::state::FreelyMutableState;
+use bevy_app::App;
+use bevy_asset::Asset;
+use bevy_ecs::{
+    error::BevyError,
+    resource::Resource,
+    schedule::{IntoScheduleConfigs, ScheduleConfigs},
+    world::FromWorld,
+};
+use bevy_platform::collections::HashMap;
+use bevy_state::state::FreelyMutableState;
+use bevy_utils::default;
 use std::any::TypeId;
 
 /// Methods to configure a loading state
@@ -62,7 +67,7 @@ pub trait ConfigureLoadingState {
 }
 
 type SchedulConfig = ScheduleConfigs<
-    Box<(dyn bevy::prelude::System<In = (), Out = Result<(), BevyError>> + 'static)>,
+    Box<(dyn bevy_ecs::system::System<In = (), Out = Result<(), BevyError>> + 'static)>,
 >;
 
 /// Can be used to add new asset collections or similar configuration to a loading state.

--- a/bevy_asset_loader/src/loading_state/dynamic_asset_systems.rs
+++ b/bevy_asset_loader/src/loading_state/dynamic_asset_systems.rs
@@ -1,11 +1,13 @@
 use crate::dynamic_asset::{DynamicAssetCollection, DynamicAssetCollections, DynamicAssets};
 use crate::loading_state::{AssetLoaderConfiguration, InternalLoadingState, LoadingAssetHandles};
-use bevy::asset::{Asset, AssetServer, Assets, LoadState};
-use bevy::ecs::system::{Res, ResMut, SystemState};
-use bevy::ecs::world::World;
-use bevy::log::{debug, warn};
-use bevy::prelude::NextState;
-use bevy::state::state::{FreelyMutableState, State};
+use bevy_asset::{Asset, AssetServer, Assets, LoadState};
+use bevy_ecs::{
+    change_detection::{Res, ResMut},
+    system::SystemState,
+    world::World,
+};
+use bevy_log::{debug, warn};
+use bevy_state::state::{FreelyMutableState, NextState, State};
 use std::any::{TypeId, type_name};
 
 #[allow(clippy::type_complexity)]

--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -5,12 +5,16 @@ use crate::loading_state::{
     AssetLoaderConfiguration, InternalLoadingState, LoadingAssetHandles, LoadingStateSchedule,
     OnEnterInternalLoadingState,
 };
-use bevy::asset::AssetServer;
-use bevy::ecs::system::SystemState;
-use bevy::ecs::world::{FromWorld, World};
-use bevy::log::{debug, info, trace, warn};
-use bevy::prelude::{NextState, Res, ResMut, Resource, Schedules};
-use bevy::state::state::{FreelyMutableState, State};
+use bevy_asset::AssetServer;
+use bevy_ecs::{
+    change_detection::{Res, ResMut},
+    resource::Resource,
+    schedule::Schedules,
+    system::SystemState,
+    world::{FromWorld, World},
+};
+use bevy_log::{debug, info, trace, warn};
+use bevy_state::state::{FreelyMutableState, NextState, State};
 #[cfg(feature = "progress_tracking")]
 use iyes_progress::{ProgressEntryId, ProgressTracker};
 use std::any::{TypeId, type_name};

--- a/bevy_asset_loader/src/mapped.rs
+++ b/bevy_asset_loader/src/mapped.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use bevy::asset::AssetPath;
+use bevy_asset::AssetPath;
 
 /// A type that can be used as key for mapped asset collection.
 ///

--- a/bevy_asset_loader/src/standard_dynamic_asset.rs
+++ b/bevy_asset_loader/src/standard_dynamic_asset.rs
@@ -1,25 +1,26 @@
 use crate::dynamic_asset::{DynamicAsset, DynamicAssetType};
 use crate::dynamic_asset::{DynamicAssetCollection, DynamicAssets};
-use bevy::asset::{Asset, AssetServer, Assets, LoadedFolder, UntypedHandle};
-use bevy::ecs::change_detection::Res;
-use bevy::ecs::system::SystemState;
-use bevy::ecs::system::command::Command;
-use bevy::ecs::world::World;
-use bevy::platform::collections::HashMap;
-use bevy::reflect::TypePath;
+use bevy_asset::{Asset, AssetServer, Assets, LoadedFolder, UntypedHandle};
+use bevy_ecs::{
+    change_detection::Res,
+    system::{Command, SystemState},
+    world::World,
+};
+use bevy_platform::collections::HashMap;
+use bevy_reflect::TypePath;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "2d")]
-use bevy::image::TextureAtlasLayout;
+use bevy_image::TextureAtlasLayout;
 #[cfg(feature = "2d")]
-use bevy::math::UVec2;
+use bevy_math::UVec2;
 #[cfg(feature = "3d")]
-use bevy::pbr::StandardMaterial;
+use bevy_pbr::StandardMaterial;
 
 #[cfg(any(feature = "3d", feature = "2d"))]
-use bevy::ecs::change_detection::ResMut;
+use bevy_ecs::change_detection::ResMut;
 #[cfg(any(feature = "3d", feature = "2d"))]
-use bevy::image::{Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor};
+use bevy_image::{Image, ImageAddressMode, ImageFilterMode, ImageSampler, ImageSamplerDescriptor};
 
 /// These asset variants can be loaded from configuration files. They will then replace
 /// a dynamic asset based on their keys.
@@ -292,7 +293,7 @@ impl DynamicAsset for StandardDynamicAsset {
 #[cfg(any(feature = "3d", feature = "2d"))]
 impl StandardDynamicAsset {
     fn update_image_sampler(
-        handle: &mut bevy::asset::Handle<Image>,
+        handle: &mut bevy_asset::Handle<Image>,
         images: &mut Assets<Image>,
         sampler_type: &ImageSamplerType,
         address_mode: &ImageAddressModeType,

--- a/bevy_asset_loader/tests/mapped_path_use_slash.rs
+++ b/bevy_asset_loader/tests/mapped_path_use_slash.rs
@@ -45,8 +45,7 @@ fn expect(collection: Option<Res<AudioCollection>>, mut exit: EventWriter<AppExi
         let files = &collection.files;
         assert!(
             files.contains_key("audio/plop.ogg"),
-            "Expected path 'audio/plop.ogg' was not in {:?}",
-            files
+            "Expected path 'audio/plop.ogg' was not in {files:?}",
         );
         exit.write(AppExit::Success);
     }


### PR DESCRIPTION
Fixes https://github.com/NiklasEi/bevy_asset_loader/issues/219.

This PR replaces https://github.com/NiklasEi/bevy_asset_loader/pull/233.

Testing:
- `cargo check --all-features` passed.
- `cargo check` passed.