### PR TITLE
Reset loading state failure tracking on re-entry

### DIFF
--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -208,6 +208,15 @@ pub(crate) fn finish_loading_state<S: FreelyMutableState>(
 pub(crate) fn reset_loading_state<S: FreelyMutableState>(world: &mut World) {
     world.remove_resource::<State<InternalLoadingState<S>>>();
     world.init_resource::<State<InternalLoadingState<S>>>();
+
+    let state = world.resource::<State<S>>().get().clone();
+    if let Some(mut config) = world.get_resource_mut::<AssetLoaderConfiguration<S>>()
+        && let Some(state_config) = config.state_configurations.get_mut(&state)
+    {
+        state_config.loading_failed = false;
+        state_config.loading_collections.clear();
+        state_config.loading_dynamic_collections.clear();
+    }
 }
 
 pub(crate) fn run_loading_state<S: FreelyMutableState>(world: &mut World) {

--- a/bevy_asset_loader/tests/reenters_failed_loading_state.rs
+++ b/bevy_asset_loader/tests/reenters_failed_loading_state.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "standard_dynamic_assets")]
+
+use bevy::app::AppExit;
+use bevy::asset::AssetPlugin;
+use bevy::audio::AudioPlugin;
+use bevy::prelude::*;
+use bevy::state::app::StatesPlugin;
+use bevy_asset_loader::prelude::*;
+
+#[test]
+fn reenters_failed_loading_state() {
+    let mut app = App::new();
+
+    app.add_plugins((
+        MinimalPlugins,
+        AssetPlugin::default(),
+        AudioPlugin::default(),
+        StatesPlugin,
+    ));
+    app.init_state::<MyStates>();
+    app.add_loading_state(
+        LoadingState::new(MyStates::Load)
+            .continue_to_state(MyStates::Next)
+            .on_failure_continue_to_state(MyStates::Error)
+            .load_collection::<Audio>(),
+    )
+    .add_systems(OnEnter(MyStates::Load), point_at_missing.run_if(run_once))
+    .add_systems(OnEnter(MyStates::Error), recover)
+    .add_systems(OnEnter(MyStates::Next), exit)
+    .add_systems(Update, timeout.run_if(in_state(MyStates::Load)))
+    .run();
+}
+
+fn point_at_missing(mut dynamic_assets: ResMut<DynamicAssets>) {
+    dynamic_assets.register_asset(
+        "sound",
+        Box::new(StandardDynamicAsset::File {
+            path: "audio/does_not_exist.ogg".to_owned(),
+        }),
+    );
+}
+
+fn recover(
+    mut dynamic_assets: ResMut<DynamicAssets>,
+    mut next: ResMut<NextState<MyStates>>,
+    mut recovered: Local<bool>,
+) {
+    assert!(
+        !*recovered,
+        "The failure state was not reset when re-entering the loading state"
+    );
+    *recovered = true;
+    dynamic_assets.register_asset(
+        "sound",
+        Box::new(StandardDynamicAsset::File {
+            path: "audio/plop.ogg".to_owned(),
+        }),
+    );
+    next.set(MyStates::Load);
+}
+
+fn exit(mut exit: MessageWriter<AppExit>) {
+    exit.write(AppExit::Success);
+}
+
+fn timeout(time: Res<Time>) {
+    if time.elapsed_secs_f64() > 10. {
+        panic!("The asset loader did not change the state in 10 seconds");
+    }
+}
+
+#[derive(AssetCollection, Resource)]
+struct Audio {
+    #[asset(key = "sound")]
+    _sound: Handle<AudioSource>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Hash, Default, States)]
+enum MyStates {
+    #[default]
+    Load,
+    Error,
+    Next,
+}


### PR DESCRIPTION
Clear `loading_failed` and the collection sets in `reset_loading_state` so a loading state that previously failed can load again on re-entry.

I hit this in my battle editor that reuses a single loading state. I can change the battle it loads (which re-enters the loading state) without restarting the program. This normally works fine, but if the first load failed (e.g., a battle whose asset files don't exist), every subsequent re-entry jumped straight back to the failure state and never retried, even after pointing it at a valid battle.

The cause is that `loading_failed` was only ever set to true on failure and cleared on success, so a state that failed once was stuck in a bad state. The leftover entries in `loading_collections` also produced "added multiple times" log warnings on re-entry. Resetting both when the state is re-entered fixes it.