### PR TITLE
Remove redundant reference in `panic!` argument

### DIFF
--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -42,7 +42,7 @@ pub(crate) fn start_loading_collection<S: FreelyMutableState, Assets: AssetColle
         .unwrap_or_else(|| {
             panic!(
                 "Could not find a loading configuration for state {:?}",
-                &state
+                state
             )
         });
     if !config.loading_collections.insert(TypeId::of::<Assets>()) {


### PR DESCRIPTION
Discovered in https://github.com/NiklasEi/bevy_asset_loader/actions/runs/29208135533/job/86691067402.