### PR TITLE
Add `ResetLoadingStateSystems` and put `reset_loading_state` in it

### DIFF
--- a/bevy_asset_loader/src/lib.rs
+++ b/bevy_asset_loader/src/lib.rs
@@ -93,7 +93,9 @@ pub mod prelude {
             DynamicAsset, DynamicAssetCollection, DynamicAssetCollections, DynamicAssetType,
             DynamicAssets,
         },
-        loading_state::{LoadingState, LoadingStateAppExt, LoadingStateSet},
+        loading_state::{
+            LoadingState, LoadingStateAppExt, LoadingStateSet, ResetLoadingStateSystems,
+        },
         mapped::{AssetFileName, AssetFileStem, AssetLabel, MapKey},
     };
 }

--- a/bevy_asset_loader/src/loading_state.rs
+++ b/bevy_asset_loader/src/loading_state.rs
@@ -392,7 +392,8 @@ where
             )
             .add_systems(
                 OnEnter(self.loading_state.clone()),
-                reset_loading_state::<S>,
+                reset_loading_state::<S>
+                    .in_set(ResetLoadingStateSystems(self.loading_state.clone())),
             )
             .configure_sets(Update, LoadingStateSet(self.loading_state.clone()));
             let mut loading_state_schedule = app.get_schedule_mut(loading_state_schedule).unwrap();
@@ -483,6 +484,13 @@ impl<S: FreelyMutableState> ConfigureLoadingState for LoadingState<S> {
 ///  Systems in this set check the loading state of assets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub struct LoadingStateSet<S: FreelyMutableState>(pub S);
+
+/// Systems in this set reset the loading state's bookkeeping when the loading
+/// state is entered. It runs in `OnEnter(loading_state)`. You can order your
+/// own `OnEnter(loading_state)` systems `after` this set to run once the
+/// loading state has been reset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
+pub struct ResetLoadingStateSystems<S: FreelyMutableState>(pub S);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, SystemSet)]
 pub(crate) enum InternalLoadingStateSet {

--- a/bevy_asset_loader/src/loading_state/systems.rs
+++ b/bevy_asset_loader/src/loading_state/systems.rs
@@ -41,7 +41,7 @@ pub(crate) fn start_loading_collection<S: FreelyMutableState, Assets: AssetColle
         .unwrap_or_else(|| {
             panic!(
                 "Could not find a loading configuration for state {:?}",
-                &state
+                state
             )
         });
     if !config.loading_collections.insert(TypeId::of::<Assets>()) {


### PR DESCRIPTION
`reset_loading_state` uses `World` to reset the loading state when the state enters.

However, because it uses `World`, this means it's ambiguous with basically anything that userland code puts in `OnEnter` for that state. Example:

```rust
app.add_systems(
    OnEnter(BootState::Loading),
    spawn_loading_screen, // <-- ambiguity warning when ambiguity detection is on
);
```

Instead, with this PR, I can now write this:

```rust
app.add_systems(
    OnEnter(BootState::Loading),
    spawn_loading_screen.after(ResetLoadingStateSystems(BootState::Loading)),
);
```

Without any noisy ambiguity warnings.

Some thoughts on the matter:

- `bevy_asset_loader`'s `reset_loading_state` is basically resetting some internal state when the state enters, and so, arguably, all userland systems probably want to run after it anyway. To run before it is semantically "wrong" even if not an actual problem today.
- Without this, I can't really enable ambiguity detection on my own OnEnter/OnExit states because I'll see all these ambiguity warnings. `reset_loading_state` isn't public so I can't refer to it to annotate that my system is ambiguous with it.
- Putting `reset_loading_state` in the system set and encouraging users to safely order after seems prudent anyway: Nothing is stopping `reset_loading_state` one day reaching into something else from `World` that is ambiguous with some userland system, even it such a change possibly would be picked up as a breaking change in code review.
- This doesn't break any users, it just puts the system in a set so userland code can order against it.
- I named the system set per Bevy's recommendations even if the existing ones in BAL are not named like this.